### PR TITLE
Implement explicit branch state management

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -31,10 +31,14 @@ if test ! -f "$1" ; then
   exit 1
 fi
 
-# # Do not create a change id if requested
-# if test "false" = "$(git config --bool --get gerrit.createChangeId)" ; then
-#   exit 0
-# fi
+BRANCH=$(git symbolic-ref --short HEAD)
+STATE=$(git config branch."$BRANCH".gherritState)
+
+# Strict Mode: Only add trailers if EXPLICITLY managed.
+# If 'unmanaged' OR 'unset', we do nothing.
+if [ "$STATE" != "managed" ]; then
+    exit 0
+fi
 
 # Do not create a change id for squash commits.
 if head -n1 "$1" | grep -q '^squash! '; then

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,8 @@
+#!/bin/bash
+# $1 = Previous HEAD, $2 = New HEAD, $3 = Flag (1=Branch checkout)
+
+# Only run on branch switches
+if [ "$3" != "1" ]; then exit 0; fi
+
+# Delegate to Rust binary
+gherrit post-checkout "$1" "$2" "$3"


### PR DESCRIPTION
*   **Explicit State Management**: Added `manage` and `unmanage` subcommands to `gherrit` to explicitly set the `branch.<name>.gherritState` git config.
*   **Auto-Configuration**: Created a `post-checkout` hook that delegates to `gherrit post-checkout`. This automatically classifies new branches as "managed" (stack mode) or "unmanaged" (collaboration mode) based on their upstream tracking configuration.
*   **Strict Push Enforcement**: Updated `pre-push` to block pushes if the branch state is ambiguous (unset).
*   **Conditional Trailers**: Updated the `commit-msg` hook to only append `gherrit-pr-id` trailers if the branch is explicitly "managed".




---

This PR is on branch [track](../tree/track).

- #44