### PR TITLE
Use G prefix in gherrit-pr-id trailers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ GHerrit will detect the changes based on the persistent `gherrit-pr-id` in the c
 
 #### `gherrit-pr-id` Trailer and Phantom Branches
 
-Inspired by Gerrit, each commit managed by GHerrit includes a trailer line in its commit message, e.g., `gherrit-pr-id: I847...`.
+Inspired by Gerrit, each commit managed by GHerrit includes a trailer line in its commit message, e.g., `gherrit-pr-id: G847...`.
 
 GitHub identifies PRs by *branch name* (specifically, a PR is a request to merge the contents of one *branch* into another). A branch can contain multiple commits, leading to a one-to-many  relationship between PRs and commits. In the Gerrit style, we want a one-to-one relationship between PRs and commits. However, Git commits do not have stable identifiers – commit hashes change on rebase, on `git commit --amend`, etc. The `gerrit-pr-id` trailer acts as a stable key for the commit that survives rebases and other commit changes.
 

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -73,7 +73,7 @@ if test -n "${reviewurl}" ; then
   pattern=".*/id/I[0-9a-f]\{40\}"
 else
   token="gherrit-pr-id"
-  value="I$random"
+  value="G$random"
   pattern=".*"
 fi
 


### PR DESCRIPTION



---

This PR is on branch [improvements](../tree/improvements).

- #46