### PR TITLE
Gracefully handle rebasing

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -31,7 +31,24 @@ if test ! -f "$1" ; then
   exit 1
 fi
 
-BRANCH=$(git symbolic-ref --short HEAD)
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+# If detached (empty BRANCH), check if we are in a rebase
+if [ -z "$BRANCH" ]; then
+    GIT_DIR=$(git rev-parse --git-dir)
+    
+    # Check for interactive rebase/merge state
+    if [ -f "$GIT_DIR/rebase-merge/head-name" ]; then
+        BRANCH=$(cat "$GIT_DIR/rebase-merge/head-name")
+    # Check for apply-based rebase state
+    elif [ -f "$GIT_DIR/rebase-apply/head-name" ]; then
+        BRANCH=$(cat "$GIT_DIR/rebase-apply/head-name")
+    fi
+    
+    # Strip the 'refs/heads/' prefix if we found a rebase branch
+    BRANCH=${BRANCH#refs/heads/}
+fi
+
 STATE=$(git config branch."$BRANCH".gherritState)
 
 # Strict Mode: Only add trailers if EXPLICITLY managed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,12 @@ fn post_checkout(_prev: &str, _new: &str, flag: &str) {
 
     let repo = gix::open(".").unwrap();
     let head = repo.head().unwrap();
-    let head_ref = head.try_into_referent().unwrap();
+
+    let head_ref = match head.try_into_referent() {
+        Some(referent) => referent,
+        None => return, // We are in detached HEAD (e.g. during rebase); do nothing.
+    };
+
     let branch_name = head_ref.name().shorten();
 
     // Idempotency check: Bail if the branch management state is already set.


### PR DESCRIPTION
- In `post-checkout`, bail during rebase
- In `commit-msg`, detect rebase and look up the branch name correctly




---

This PR is on branch [improvements](../tree/improvements).

- #48
- #47
- #49