### PR TITLE
Move git hooks under `hook` command, hide from help text

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -5,4 +5,4 @@
 if [ "$3" != "1" ]; then exit 0; fi
 
 # Delegate to Rust binary
-gherrit post-checkout "$1" "$2" "$3"
+gherrit hook post-checkout "$1" "$2" "$3"

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-gherrit pre-push
+gherrit hook pre-push
 exit $?


### PR DESCRIPTION



---

- #84
- #83
- #82
- #81
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G22d29bd04e93027edcd0d9f0ad5c380aeb2d5beb", "parent": "Ga20fc238c5f31e035ce1292bcfec466dcc690fd0", "child": "G62f16d687240829164d9b941a910c74281bd867d"} -->