### PR TITLE
[pre-push] Push atomically

### DIFF
--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -126,6 +126,10 @@ fn push_to_origin(
         // Use --force-with-lease to ensure we don't overwrite remote changes
         // that we haven't seen (i.e. if the remote ref has moved since we last fetched).
         "--force-with-lease".to_string(),
+        // If any push fails, abort the entire push instead of leaving GitHub with refs
+        // that don't correspond to any PR. Mostly commonly, this is caused by
+        // --force-with-lease causing some refs to fail to push.
+        "--atomic".to_string(),
         "origin".to_string(),
     ];
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This avoids cluttering GitHub with refs which aren't associated with any
PR.




---

- #98
- #95
- #96
- #94
- #97

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G3311ff25ab86cf530311e36bbd5341870e913cd5", "parent": "G7bc763751cb4ac5289b6e00f35cf62a2f7e64dce", "child": "G582bbdae9bb1e48729f68075315d8d21f7200a48"} -->