### PR TITLE
Replace branch "privacy" with pushRemote config

### DIFF
--- a/src/manage.rs
+++ b/src/manage.rs
@@ -33,8 +33,30 @@ pub fn set_state(state: State) {
     )
     .unwrap_status();
     match state {
-        State::Managed => log::info!("Branch '{}' is now managed by GHerrit.", branch_name),
-        State::Unmanaged => log::info!("Branch '{}' is now unmanaged by GHerrit.", branch_name),
+        State::Managed => {
+            // Set pushRemote to "." (current directory).
+            // This makes `git push` a local no-op.
+            // Result:
+            // 1. `pre-push` hook runs and syncs to GitHub (exit 0).
+            // 2. Git pushes to `.` (succeeds instantly with no effect).
+            // 3. User sees success, and `origin/branch` is NOT updated
+            //    (Private).
+            cmd!("git config", "branch.{branch_name}.pushRemote", ".").unwrap_status();
+
+            log::info!("Branch '{branch_name}' is now managed by GHerrit.");
+            log::info!("  - 'git push' is now configured to sync your stack WITHOUT updating 'origin/{branch_name}'");
+            log::info!("  - To allow pushing this branch to origin (making it public), run:");
+            log::info!("    git config --unset branch.{branch_name}.pushRemote");
+        }
+        State::Unmanaged => {
+            // Remove the pushRemote override to restore standard Git behavior.
+            // Use `.unwrap_status()` and ignore errors (in case the config key
+            // doesn't exist).
+            let _ = cmd!("git config --unset", "branch.{branch_name}.pushRemote").unwrap_status();
+
+            log::info!("Branch '{branch_name}' is now unmanaged by GHerrit.");
+            log::info!("  - Standard 'git push' behavior has been restored.");
+        }
     }
 }
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Instead of tracking whether a branch is "private" (as a GHerrit
setting), set `pushRemote = "."` when running `gherrit manage` (and
unset it when running `gherrit unmanage`). In the `pre-push` hook,
unconditionally exit 0. `pushRemote = "."` will have the effect of `git
push` pushing to "this" local repo, which is an effect-free no-op. This
allows us to remove the warning text about intentionally making `git
push` fail.

Closes #93




---

- #98
- #95
- #96
- #94
- #97

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G582bbdae9bb1e48729f68075315d8d21f7200a48", "parent": "G3311ff25ab86cf530311e36bbd5341870e913cd5", "child": null} -->