### PR TITLE
Be more robust when determining branch name

### DIFF
--- a/src/manage.rs
+++ b/src/manage.rs
@@ -33,7 +33,7 @@ pub fn get_state(repo: &util::Repo, branch_name: &str) -> Result<Option<State>> 
 pub fn set_state(repo: &util::Repo, state: State) -> Result<()> {
     let branch_name = repo.current_branch();
     let branch_name = match branch_name {
-        HeadState::Attached(bn) | HeadState::Rebasing(bn) => bn,
+        HeadState::Attached(bn) | HeadState::Pending(bn) => bn,
         HeadState::Detached => {
             bail!("Cannot set state for detached HEAD");
         }
@@ -92,7 +92,7 @@ pub fn post_checkout(repo: &util::Repo, _prev: &str, _new: &str, flag: &str) -> 
     let branch_name = repo.current_branch();
     let branch_name = match branch_name {
         HeadState::Attached(bn) => bn,
-        HeadState::Rebasing(_) | HeadState::Detached => return Ok(()),
+        HeadState::Pending(_) | HeadState::Detached => return Ok(()),
     };
 
     // Idempotency check: Bail if the branch management state is already set.

--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -25,7 +25,7 @@ pub fn run(repo: &util::Repo) -> Result<()> {
 
     let branch_name = repo.current_branch();
     let branch_name = match branch_name {
-        HeadState::Attached(bn) | HeadState::Rebasing(bn) => bn,
+        HeadState::Attached(bn) | HeadState::Pending(bn) => bn,
         HeadState::Detached => {
             bail!("Cannot push from detached HEAD");
         }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

When we are not in an attached HEAD state, use gix's `repo.state()` to
determine whether we're rebasing instead of relying on fragile
filesystem layout details.




---

- #117

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G1a7b75af8d9db3d95b197e36484b42f2ca5354f3", "parent": null, "child": null} -->