### PR TITLE
[util] Make find_default_branches infallible

### DIFF
--- a/src/manage.rs
+++ b/src/manage.rs
@@ -160,14 +160,13 @@ pub fn post_checkout(repo: &util::Repo, _prev: &str, _new: &str, flag: &str) -> 
         .config_string(&format!("branch.{branch_name}.merge"))
         .wrap_err("Failed to read config")?;
 
-    let is_default_branch = if let (Some(_remote), Some(merge)) =
-        (upstream_remote.as_deref(), upstream_merge.as_deref())
-    {
-        let branch_name = merge.strip_prefix("refs/heads/").unwrap_or(merge);
-        repo.is_a_default_branch_on_default_remote(branch_name)?
-    } else {
-        false
-    };
+    let is_default_branch = upstream_merge
+        .as_deref()
+        .map(|merge| {
+            let branch_name = merge.strip_prefix("refs/heads/").unwrap_or(merge);
+            repo.is_a_default_branch_on_default_remote(branch_name)
+        })
+        .unwrap_or(false);
 
     let has_upstream = upstream_remote.is_some() && upstream_merge.is_some();
     if has_upstream && !is_default_branch {

--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -73,7 +73,7 @@ fn check_managed_state(repo: &util::Repo, branch_name: &str) -> Result<()> {
 
 fn collect_commits(repo: &util::Repo) -> Result<Vec<Commit>> {
     let head = repo.rev_parse_single("HEAD")?;
-    let default_branch = repo.find_default_branch_on_default_remote()?;
+    let default_branch = repo.find_default_branch_on_default_remote();
     let default_ref_spec = format!("refs/heads/{}", default_branch);
     let default_ref = repo.rev_parse_single(default_ref_spec.as_str())?;
     let mut commits = repo
@@ -206,9 +206,7 @@ fn push_to_origin(repo: &util::Repo, commits: &[Commit]) -> Result<HashMap<Strin
     let status = child.wait().unwrap();
     if !status.success() {
         let r = repo.default_remote_name();
-        let b = repo
-            .find_default_branch_on_default_remote()
-            .unwrap_or("main".to_string());
+        let b = repo.find_default_branch_on_default_remote();
         bail!("`git push` failed. You may need to rebase on the latest changes from {r}/{b}.");
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -162,7 +162,7 @@ impl Repo {
             .unwrap_or_else(|| "origin".to_string())
     }
 
-    fn find_default_branches(&self, remote_name: &str) -> Result<Vec<String>> {
+    fn find_default_branches(&self, remote_name: &str) -> Vec<String> {
         let mut branches = Vec::new();
 
         // Try to infer the default branch from the remote HEAD.
@@ -181,7 +181,9 @@ impl Repo {
         }
 
         // Check git config
-        if let Some(default_branch) = self.config_string("init.defaultBranch")? {
+        //
+        // Note that we swallow errors (e.g. invalid UTF-8) here.
+        if let Some(default_branch) = self.config_string("init.defaultBranch").ok().flatten() {
             branches.push(default_branch);
         }
 
@@ -195,20 +197,20 @@ impl Repo {
         // Default fallback
         branches.push("main".to_string());
 
-        Ok(branches)
+        branches
     }
 
-    pub fn find_default_branch_on_default_remote(&self) -> Result<String> {
-        let branches = self.find_default_branches(&self.default_remote_name())?;
-        Ok(branches
+    pub fn find_default_branch_on_default_remote(&self) -> String {
+        let branches = self.find_default_branches(&self.default_remote_name());
+        branches
             .first()
             .cloned()
-            .unwrap_or_else(|| "main".to_string()))
+            .unwrap_or_else(|| "main".to_string())
     }
 
-    pub fn is_a_default_branch_on_default_remote(&self, branch_name: &str) -> Result<bool> {
-        let branches = self.find_default_branches(&self.default_remote_name())?;
-        Ok(branches.iter().any(|b| b == branch_name))
+    pub fn is_a_default_branch_on_default_remote(&self, branch_name: &str) -> bool {
+        let branches = self.find_default_branches(&self.default_remote_name());
+        branches.iter().any(|b| b == branch_name)
     }
 }
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Its failure condition isn't fatal – we can just ignore when a local
config value fails to parse.




---

- #130
- #129
- #128
- #126
- #125

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G71535a281fcd4c925be6da34c6e6a4f7a7b8c29d", "parent": null, "child": "G5c13d8ad2ca1916a7e5a2a8882945c2d8e16b3fc"} -->