### PR TITLE
[commit-msg] Remove vestigal Gerrit support

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -65,11 +65,11 @@ macro_rules! cmd {
 macro_rules! re {
     ($name:ident, $re:literal) => {
         fn $name() -> &'static regex::Regex {
-            re!(@inner $re)
+            $crate::re!(@inner $re)
         }
     };
     ($re:literal) => {
-        re!(@inner $re)
+        $crate::re!(@inner $re)
     };
     (@inner $re:literal) => {{
         static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| regex::Regex::new($re).unwrap());


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Probably left in by accident from when we converted from Gerrit's
commit-msg shell script.




---

- #134
- #135
- #132


**Latest Update:** v2 — [Compare vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G346967d337aa3ae757d709dfaba70f0f3ddee28f/v1..gherrit/G346967d337aa3ae757d709dfaba70f0f3ddee28f/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 |
| :--- | :--- | :--- |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G346967d337aa3ae757d709dfaba70f0f3ddee28f/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G346967d337aa3ae757d709dfaba70f0f3ddee28f/v1..gherrit/G346967d337aa3ae757d709dfaba70f0f3ddee28f/v2) |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G346967d337aa3ae757d709dfaba70f0f3ddee28f/v1) | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G346967d337aa3ae757d709dfaba70f0f3ddee28f", "parent": null, "child": "G7862854e1ca2bede6a862ca055fab380f651b654"} -->