### PR TITLE
[commit-msg] Document squash commit skipping

### DIFF
--- a/src/commit_msg.rs
+++ b/src/commit_msg.rs
@@ -48,7 +48,10 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
         return Ok(());
     }
 
-    // Squash check
+    // Skip temporary squash commits (e.g. from `git commit --squash`) to
+    // prevent creating "phantom" PRs for changes destined to be merged away.
+    // These commits are transient and shouldn't be part of the persistent
+    // managed stack.
     let msg_content = fs::read_to_string(msg_path).wrap_err("Failed to read msg file")?;
     if msg_content
         .lines()

--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -124,8 +124,8 @@ fn push_to_origin(repo: &util::Repo, commits: &[Commit]) -> Result<HashMap<Strin
 
     let mut next_versions = HashMap::new();
 
-    // Windows command line limit is ~32k chars. Each commit generates ~200 chars
-    // of refspecs (1 branch ref + 1 tag ref).
+    // Windows command line limit is ~32k chars. Each commit generates ~200
+    // chars of refspecs (1 branch ref + 1 tag ref).
     // 80 * 200 = 16,000 chars, leaving plenty of headroom.
     const BATCH_SIZE: usize = 80;
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #134
- #135


**Latest Update:** v3 — [Compare vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v2..gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 |
| :--- | :--- | :--- | :--- |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v1..gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v2..gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v3) |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v1..gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v2) | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G7862854e1ca2bede6a862ca055fab380f651b654/v1) | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G7862854e1ca2bede6a862ca055fab380f651b654", "parent": null, "child": "G66bea0f5637d6658b46d71ef3378416d983f8576"} -->