### PR TITLE
[test] Rely on commit-msg hook

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -24,24 +24,18 @@ fn test_commit_msg_hook() {
 #[test]
 fn test_full_stack_lifecycle_mocked() {
     let ctx = TestContext::init();
+    ctx.install_hooks();
 
     // Setup: Create 'main' and a feature branch
     ctx.run_git(&["commit", "--allow-empty", "-m", "Initial Commit"]);
     ctx.run_git(&["checkout", "-b", "feature-stack"]);
-    ctx.run_git(&[
-        "commit",
-        "--allow-empty",
-        "-m",
-        "Commit A\n\ngherrit-pr-id: G1",
-    ]);
-    ctx.run_git(&[
-        "commit",
-        "--allow-empty",
-        "-m",
-        "Commit B\n\ngherrit-pr-id: G2",
-    ]);
 
+    // Manage the branch properly before making commits so hooks are installed
     ctx.gherrit().args(["manage"]).assert().success();
+
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Commit A"]);
+
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Commit B"]);
 
     // Trigger Pre-Push Hook (Simulate 'git push'). We call the hook directly
     // because simulating a real 'git push' that calls the hook recursively is


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

...instead of manually editing commit messages with `gherrit-pr-id`
trailers.




---

- #150
- #146
- #151
- #149
- #144
- #147
- #145
- #148
- #143
- #142
- #140
- #137
- #138


**Latest Update:** v2 — [Compare vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Gd494213254638f2c2c0ac51e253e489d2aa0751c/v1..gherrit/Gd494213254638f2c2c0ac51e253e489d2aa0751c/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 |
| :--- | :--- | :--- |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gd494213254638f2c2c0ac51e253e489d2aa0751c/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Gd494213254638f2c2c0ac51e253e489d2aa0751c/v1..gherrit/Gd494213254638f2c2c0ac51e253e489d2aa0751c/v2) |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gd494213254638f2c2c0ac51e253e489d2aa0751c/v1) | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "Gd494213254638f2c2c0ac51e253e489d2aa0751c", "parent": null, "child": "G204615f969de97ecc49525d43c22f33a28ed18ba"} -->