### PR TITLE
[pre-push] Delete old, unneeded version tags

### DIFF
--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -245,6 +245,34 @@ fn push_to_origin(repo: &util::Repo, commits: &[Commit]) -> Result<HashMap<Strin
                 PreviousValue::Any,
                 "gherrit: persist local version state",
             );
+
+            // [Clean Up Old Versions]
+            // Iterate over all references to find and delete old tags for this specific ID.
+            let prefix = format!("refs/tags/gherrit/{gherrit_id}/");
+
+            // Note: We use manual filtering as established in get_local_version
+            if let Ok(references) = repo.references().map_err(|e| eyre!(e)) {
+                if let Ok(iter) = references.all().map_err(|e| eyre!(e)) {
+                    for reference in iter.filter_map(Result::ok) {
+                        let name = reference.name().as_bstr().to_string();
+
+                        if let Some(suffix) = name.strip_prefix(&prefix) {
+                            if let Some(ver_str) = suffix.strip_prefix("v") {
+                                if let Ok(old_ver) = ver_str.parse::<usize>() {
+                                    // CRITICAL: Only delete if strictly older than the current version.
+                                    if old_ver < ver {
+                                        log::debug!("Cleaning up obsolete tag: {name}");
+                                        // Best effort deletion
+                                        if let Ok(r) = repo.find_reference(&name) {
+                                            let _ = r.delete();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

TODO: This may be pointless – it looks like `git pull` just re-fetches
them from the remote anyway.

Once version tag N has been successfully pushed to GitHub, versions N-1
and below are no longer used for anything. This commit updates the
pre-push hook to delete these.

Makes progress on #141




---

- #143
- #150
- #146
- #151
- #149
- #144
- #147
- #145
- #148


**Latest Update:** v3 — [Compare vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v2..gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 |
| :--- | :--- | :--- | :--- |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/G6d0886a02b8232200b80561878009ecdec568036..gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v1..gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v2..gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v3) |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/G6d0886a02b8232200b80561878009ecdec568036..gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v1..gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v2) | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/G6d0886a02b8232200b80561878009ecdec568036..gherrit/G550a3c766a77abb6f4efd54cd597befd31d41ec3/v1) | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G550a3c766a77abb6f4efd54cd597befd31d41ec3", "parent": "G6d0886a02b8232200b80561878009ecdec568036", "child": null} -->