### PR TITLE
[test] Verify behavior with orphaned branches

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -142,7 +142,10 @@ impl Repo {
     }
 
     pub fn is_newly_created_branch(&self, branch_name: &str) -> Result<bool> {
-        let reference = self.inner.find_reference(branch_name)?;
+        let reference = match self.inner.find_reference(branch_name) {
+            Ok(r) => r,
+            Err(_) => return Ok(true),
+        };
 
         // Get the most recent reflog entry
         let latest_log = reference
@@ -158,8 +161,10 @@ impl Repo {
 
     /// Checks if `ancestor` is reachable from `descendant`.
     pub fn is_ancestor(&self, ancestor: gix::ObjectId, descendant: gix::ObjectId) -> Result<bool> {
-        let merge_base = self.inner.merge_base(ancestor, descendant)?;
-        Ok(merge_base.detach() == ancestor)
+        match self.inner.merge_base(ancestor, descendant) {
+            Ok(merge_base) => Ok(merge_base.detach() == ancestor),
+            Err(_) => Ok(false),
+        }
     }
 
     pub fn default_remote_name(&self) -> String {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #143
- #150
- #146
- #151
- #149
- #144
- #147
- #145
- #148


**Latest Update:** v3 — [Compare vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v2..gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 |
| :--- | :--- | :--- | :--- |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/G8c0f07abcd74caef797a88bff4a5e3a8393af54b..gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v1..gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v2..gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v3) |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/G8c0f07abcd74caef797a88bff4a5e3a8393af54b..gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v1..gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v2) | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/G8c0f07abcd74caef797a88bff4a5e3a8393af54b..gherrit/G7b866c0a517f51057c5567f8fd49666cc6f1eca0/v1) | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G7b866c0a517f51057c5567f8fd49666cc6f1eca0", "parent": "G8c0f07abcd74caef797a88bff4a5e3a8393af54b", "child": "G5ea7457d98f4f32023af8f95057e61c3afd67764"} -->