### PR TITLE
[test] Fill test gaps

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -387,9 +387,43 @@ fn test_pr_body_generation() {
         );
     }
 
-    // Now let's amend B to create v2 and verify table appears?
-    // That would duplicate version increment test somewhat, but good for body check.
-    // Let's assume v1 check is sufficient for metadata structure.
+    // 4. Update to v2 to verify the Patch History Table appears
+    ctx.run_git(&["checkout", "feature-stack"]); // Ensure we are on the branch
+
+    // Amend "Commit B" (the middle one)
+    // We need to re-find it. Since we are in a stack, we can just amend HEAD~1
+    // but that's risky if the graph is complex.
+    // Easier: Just amend the tip (Commit C). The table should appear on Commit C's PR too.
+    ctx.run_git(&["commit", "--amend", "--allow-empty", "--no-edit"]);
+
+    // Sync again
+    // ctx.gherrit().args(["hook", "pre-push"]).assert().success(); // Manual assert below for capture
+    let assert = ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    let output = assert.get_output();
+    println!(
+        "GHERRIT STDERR (v2):\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    if !ctx.is_live {
+        let state = ctx.read_mock_state();
+        // Find PR for Commit C (the tip)
+        let pr_c = state
+            .prs
+            .iter()
+            .find(|pr| pr.title == "Commit C")
+            .expect("PR for Commit C not found");
+
+        let body = &pr_c.body;
+        println!("DEBUG: PR Body for Commit C (v2):\n{}", body);
+
+        // Assert table exists now
+        assert!(
+            body.contains("| Version |"),
+            "Patch History Table should appear for v2"
+        );
+        assert!(body.contains("v1 |"), "Table should reference v1");
+    }
 }
 
 #[test]
@@ -465,4 +499,48 @@ fn test_rebase_detection() {
         .assert()
         .success()
         .stdout("true\n");
+}
+
+#[test]
+fn test_public_stack_links() {
+    let ctx = TestContext::init();
+    ctx.install_hooks();
+
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Init"]);
+    ctx.run_git(&["checkout", "-b", "public-feature"]);
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Public Commit"]);
+
+    // 1. Private Mode (Default)
+    ctx.gherrit().args(["manage"]).assert().success();
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+
+    if !ctx.is_live {
+        let state = ctx.read_mock_state();
+        let body = &state.prs[0].body;
+        assert!(
+            !body.contains("This PR is on branch"),
+            "Private stack should NOT link to local branch"
+        );
+    }
+
+    // 2. Public Mode
+    // Manually set pushRemote to origin (simulating a public stack)
+    ctx.run_git(&["config", "branch.public-feature.pushRemote", "origin"]);
+
+    // Force an update so the body regenerates (amend commit)
+    ctx.run_git(&["commit", "--amend", "--allow-empty", "--no-edit"]);
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+
+    if !ctx.is_live {
+        let state = ctx.read_mock_state();
+        let body = &state.prs[0].body; // Get the updated body
+        assert!(
+            body.contains("This PR is on branch"),
+            "Public stack SHOULD link to local branch"
+        );
+        assert!(
+            body.contains("[public-feature]"),
+            "Link should mention the branch name"
+        );
+    }
 }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

TODO: Commit message




---

- #143
- #150
- #146
- #151
- #149
- #144
- #147
- #145
- #148


**Latest Update:** v3 — [Compare vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v2..gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 |
| :--- | :--- | :--- | :--- |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/G79000d9d73b080807f6536b20203a04aaff2950b..gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v1..gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v2..gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v3) |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/G79000d9d73b080807f6536b20203a04aaff2950b..gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v1..gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v2) | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/G79000d9d73b080807f6536b20203a04aaff2950b..gherrit/G721a8c9a60beddc3c49fc256aecda3c4d79e50f6/v1) | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G721a8c9a60beddc3c49fc256aecda3c4d79e50f6", "parent": "G79000d9d73b080807f6536b20203a04aaff2950b", "child": "G6d0886a02b8232200b80561878009ecdec568036"} -->