### PR TITLE
[test] Test branch name detection during rebase

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -437,3 +437,32 @@ fn test_large_stack_batching() {
         );
     }
 }
+
+#[test]
+fn test_rebase_detection() {
+    let ctx = TestContext::init();
+    ctx.install_hooks();
+
+    // Setup: Main and feature
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Initial"]);
+    ctx.run_git(&["checkout", "-b", "feature-rebase"]);
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Feature Work"]);
+
+    // Detach HEAD to simulate rebase state
+    ctx.run_git(&["checkout", "--detach"]);
+
+    // Create rebase-merge state manually
+    let rebase_dir = ctx.repo_path.join(".git/rebase-merge");
+    std::fs::create_dir_all(&rebase_dir).unwrap();
+    std::fs::write(rebase_dir.join("head-name"), "refs/heads/feature-rebase").unwrap();
+
+    // Run manage - should succeed by detecting 'feature-rebase'
+    ctx.gherrit().args(["manage"]).assert().success();
+
+    // Verify config was applied to 'feature-rebase'
+    ctx.git()
+        .args(["config", "branch.feature-rebase.gherritManaged"])
+        .assert()
+        .success()
+        .stdout("true\n");
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #143
- #150
- #146
- #151
- #149
- #144
- #147
- #145
- #148


**Latest Update:** v3 — [Compare vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v2..gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 |
| :--- | :--- | :--- | :--- |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d..gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v1..gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v2..gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v3) |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d..gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v1..gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v2) | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d..gherrit/G79000d9d73b080807f6536b20203a04aaff2950b/v1) | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G79000d9d73b080807f6536b20203a04aaff2950b", "parent": "Ge54ee7021ab98716535ad0506d1bef6d1ca3771d", "child": "G721a8c9a60beddc3c49fc256aecda3c4d79e50f6"} -->