### PR TITLE
[test] Verify version tag update behavior

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -256,3 +256,58 @@ fn test_pre_push_ancestry_check() {
         stderr
     );
 }
+
+#[test]
+fn test_version_increment() {
+    let ctx = TestContext::init();
+    ctx.install_hooks();
+
+    // Setup: Initial commit
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Initial Commit"]);
+    // Create feature branch
+    ctx.run_git(&["checkout", "-b", "feat-versioning"]);
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Feature Commit"]);
+
+    // Manage
+    ctx.gherrit().args(["manage"]).assert().success();
+
+    // Push 1 (v1)
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+
+    let mut pushed_count_v1 = 0;
+    if !ctx.is_live {
+        let state = ctx.read_mock_state();
+        let has_v1 = state.pushed_refs.iter().any(|r| r.contains("/v1"));
+        assert!(
+            has_v1,
+            "Expected v1 tag to be pushed. Refs: {:?}",
+            state.pushed_refs
+        );
+        pushed_count_v1 = state.pushed_refs.len();
+    }
+
+    // Amend commit (modifies SHA, keeps Change-ID)
+    ctx.run_git(&["commit", "--amend", "--allow-empty", "--no-edit"]);
+
+    // Push 2 (v2)
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+
+    if !ctx.is_live {
+        let state = ctx.read_mock_state();
+        let has_v2 = state.pushed_refs.iter().any(|r| r.contains("/v2"));
+        assert!(
+            has_v2,
+            "Expected v2 tag to be pushed. Refs: {:?}",
+            state.pushed_refs
+        );
+
+        // We check the *new* pushes only.
+        let new_pushes = &state.pushed_refs[pushed_count_v1..];
+        let v1_repush = new_pushes.iter().any(|r| r.contains("/v1"));
+        assert!(
+            !v1_repush,
+            "v1 tag should NOT be pushed again in the second push. New pushes: {:?}",
+            new_pushes
+        );
+    }
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #160
- #159
- #156
- #157
- #154
- #158
- #153


**Latest Update:** v6 — [Compare vs v5](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v5..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v6 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v6) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v1..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v6) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v2..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v6) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v3..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v6) | [vs v4](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v4..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v6) | [vs v5](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v5..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v6) |
| v5 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v5) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v1..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v5) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v2..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v5) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v3..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v5) | [vs v4](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v4..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v5) | |
| v4 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v4) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v1..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v4) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v2..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v4) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v3..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v4) | | |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v1..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v2..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v3) | | | |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v1..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v2) | | | | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G5ea7457d98f4f32023af8f95057e61c3afd67764/v1) | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G5ea7457d98f4f32023af8f95057e61c3afd67764", "parent": null, "child": "Gc7b70a2ba27f2220345dc04af88f34017cf3542b"} -->