### PR TITLE
[test] Test that large stacks are batched

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -116,6 +116,8 @@ fn run_git_cmd(path: &Path, args: &[&str]) {
 pub struct MockState {
     pub prs: Vec<PrEntry>,
     pub pushed_refs: Vec<String>,
+    #[serde(default)]
+    pub push_count: usize,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -381,3 +381,55 @@ fn test_pr_body_generation() {
         );
     }
 }
+
+#[test]
+fn test_large_stack_batching() {
+    let ctx = TestContext::init();
+    ctx.install_hooks();
+
+    // Setup: Initial commit on main
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Initial Commit"]);
+
+    // Create feature branch
+    ctx.run_git(&["checkout", "-b", "large-stack"]);
+
+    // Create 85 commits (exceeds batch limit of 80)
+    for i in 1..=85 {
+        ctx.run_git(&["commit", "--allow-empty", "-m", &format!("Commit {}", i)]);
+    }
+
+    // Manage
+    ctx.gherrit().args(["manage"]).assert().success();
+
+    // Sync - should succeed without error
+    // Using simple pre-push hook invocation.
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+
+    if !ctx.is_live {
+        let state = ctx.read_mock_state();
+
+        // Assert: 85 PRs created
+        assert_eq!(state.prs.len(), 85, "Expected 85 PRs created");
+
+        // Assert: 85 refs pushed (actually more, since tags are also pushed)
+        // Check refs/gherrit/<ID>/v1 count.
+        let v1_refs = state
+            .pushed_refs
+            .iter()
+            .filter(|r| !r.starts_with("--"))
+            .filter(|r| r.contains("/v1"))
+            .count();
+        assert_eq!(
+            v1_refs,
+            85,
+            "Expected 85 v1 specific refs pushed. Total pushed: {:?}",
+            state.pushed_refs.len()
+        );
+
+        // Assert: Push was split into 2 batches (80 + 5)
+        assert_eq!(
+            state.push_count, 2,
+            "Expected 2 push invocations for 85 commits (batch size 80)"
+        );
+    }
+}

--- a/tests/support/mock_bin.rs
+++ b/tests/support/mock_bin.rs
@@ -11,6 +11,8 @@ struct MockState {
     prs: Vec<PrEntry>,
     #[serde(default)]
     pushed_refs: Vec<String>,
+    #[serde(default)]
+    push_count: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -55,6 +57,7 @@ fn handle_git(args: &[String]) {
 
         update_state(|state| {
             state.pushed_refs.extend(refspecs);
+            state.push_count += 1;
         });
 
         // Pretend push succeeded


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #160
- #159
- #156
- #157
- #154


**Latest Update:** v9 — [Compare vs v8](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 | v6 | v7 | v8 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v9 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v9) |
| v8 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v8) | |
| v7 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v7) | | |
| v6 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v6) | | | |
| v5 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v5) | | | | |
| v4 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v4) | | | | | |
| v3 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v3) | | | | | | |
| v2 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v2) | | | | | | | |
| v1 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge54ee7021ab98716535ad0506d1bef6d1ca3771d/v1) | | | | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "Ge54ee7021ab98716535ad0506d1bef6d1ca3771d", "parent": null, "child": "G79000d9d73b080807f6536b20203a04aaff2950b"} -->