### PR TITLE
[test] Assert number of commits synced...

### DIFF
--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -69,7 +69,11 @@ pub async fn run(repo: &util::Repo) -> Result<()> {
 
     let octocrab = builder.build()?;
 
-    sync_prs(repo, &octocrab, branch_name, commits, latest_versions).await
+    let num_commits = commits.len();
+    sync_prs(repo, &octocrab, branch_name, commits, latest_versions).await?;
+
+    log::info!("Successfully synced {num_commits} commits.");
+    Ok(())
 }
 
 fn collect_commits(repo: &util::Repo) -> Result<Vec<Commit>> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -35,7 +35,12 @@ fn test_full_stack_lifecycle_mocked() {
     // Trigger Pre-Push Hook (Simulate 'git push'). We call the hook directly
     // because simulating a real 'git push' that calls the hook recursively is
     // complex in a test env.
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    // Verify valid sync
+    ctx.gherrit()
+        .args(["hook", "pre-push"])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("Successfully synced 2 commits"));
 
     // Verify Side Effects (Mock Only)
     if !ctx.is_live {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

...in test_full_stack_lifecycle_mocked




---

- #186


**Latest Update:** v8 — [Compare vs v7](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 | v6 | v7 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v8 | [vs Base](https://github.com/joshlf/gherrit/pull/186/compare/main..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8) | [vs v1](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v1..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8) | [vs v2](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v2..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8) | [vs v3](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v3..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8) | [vs v4](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v4..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8) | [vs v5](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v5..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8) | [vs v6](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v6..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8) | [vs v7](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v8) |
| v7 | [vs Base](https://github.com/joshlf/gherrit/pull/186/compare/main..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7) | [vs v1](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v1..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7) | [vs v2](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v2..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7) | [vs v3](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v3..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7) | [vs v4](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v4..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7) | [vs v5](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v5..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7) | [vs v6](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v6..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v7) | |
| v6 | [vs Base](https://github.com/joshlf/gherrit/pull/186/compare/main..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v6) | [vs v1](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v1..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v6) | [vs v2](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v2..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v6) | [vs v3](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v3..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v6) | [vs v4](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v4..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v6) | [vs v5](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v5..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v6) | | |
| v5 | [vs Base](https://github.com/joshlf/gherrit/pull/186/compare/main..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v5) | [vs v1](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v1..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v5) | [vs v2](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v2..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v5) | [vs v3](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v3..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v5) | [vs v4](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v4..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v5) | | | |
| v4 | [vs Base](https://github.com/joshlf/gherrit/pull/186/compare/main..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v4) | [vs v1](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v1..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v4) | [vs v2](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v2..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v4) | [vs v3](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v3..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v4) | | | | |
| v3 | [vs Base](https://github.com/joshlf/gherrit/pull/186/compare/main..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v3) | [vs v1](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v1..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v3) | [vs v2](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v2..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v3) | | | | | |
| v2 | [vs Base](https://github.com/joshlf/gherrit/pull/186/compare/main..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v2) | [vs v1](https://github.com/joshlf/gherrit/pull/186/compare/gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v1..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v2) | | | | | | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/pull/186/compare/main..gherrit/G2008befff15eaa0ecd53501358f32a8cc7cc354d/v1) | | | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G2008befff15eaa0ecd53501358f32a8cc7cc354d", "parent": null, "child": null} -->