### PR TITLE
[commit-msg] Randomize `gherrit-pr-id` generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -669,7 +669,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -755,7 +755,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -961,6 +961,7 @@ dependencies = [
  "octocrab",
  "owo-colors",
  "predicates",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "serde",
@@ -1874,7 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2319,7 +2320,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
@@ -2490,7 +2491,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2851,8 +2852,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2862,7 +2873,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2872,6 +2893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2969,7 +2999,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -3288,7 +3318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ eyre = "0.6"
 color-eyre = "0.6"
 owo-colors = "4.2"
 octocrab = "0.48.1"
+rand = "0.9.2"
 tokio = { version = "1.48.0", features = ["full"] }
 itertools = "0.14.0"
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

In addition to the existing mechanism of hashing the incoming object,
also mix in a random salt. This helps to prevent collisions in a number
of practical scenarios:
- When identical commits are created at the same time
- In testing, when hermeticity reduces sources of entropy

Makes progress on #171




---

- #187


**Latest Update:** v7 — [Compare vs v6](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v6..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v7)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 | v6 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v7 | [vs Base](https://github.com/joshlf/gherrit/pull/187/compare/main..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v7) | [vs v1](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v1..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v7) | [vs v2](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v2..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v7) | [vs v3](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v3..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v7) | [vs v4](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v4..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v7) | [vs v5](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v5..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v7) | [vs v6](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v6..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v7) |
| v6 | [vs Base](https://github.com/joshlf/gherrit/pull/187/compare/main..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v6) | [vs v1](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v1..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v6) | [vs v2](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v2..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v6) | [vs v3](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v3..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v6) | [vs v4](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v4..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v6) | [vs v5](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v5..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v6) | |
| v5 | [vs Base](https://github.com/joshlf/gherrit/pull/187/compare/main..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v5) | [vs v1](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v1..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v5) | [vs v2](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v2..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v5) | [vs v3](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v3..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v5) | [vs v4](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v4..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v5) | | |
| v4 | [vs Base](https://github.com/joshlf/gherrit/pull/187/compare/main..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v4) | [vs v1](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v1..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v4) | [vs v2](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v2..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v4) | [vs v3](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v3..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v4) | | | |
| v3 | [vs Base](https://github.com/joshlf/gherrit/pull/187/compare/main..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v3) | [vs v1](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v1..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v3) | [vs v2](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v2..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v3) | | | | |
| v2 | [vs Base](https://github.com/joshlf/gherrit/pull/187/compare/main..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v2) | [vs v1](https://github.com/joshlf/gherrit/pull/187/compare/gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v1..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v2) | | | | | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/pull/187/compare/main..gherrit/G5a11ceea59250b9e7c843b3337e2932ce6b8821a/v1) | | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G5a11ceea59250b9e7c843b3337e2932ce6b8821a", "parent": null, "child": null} -->