### PR TITLE
[pre-push] Improve UX for `fixup!` etc commits

### DIFF
--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -101,7 +101,29 @@ fn collect_commits(repo: &util::Repo) -> Result<Vec<Commit>> {
         .collect::<Result<Vec<_>>>()?;
     commits.reverse();
 
-    commits.into_iter().map(|c| c.try_into()).collect()
+    let remote = repo.default_remote_name();
+    commits
+        .into_iter()
+        .map(|c| -> Result<Commit> {
+            let msg = c.message()?;
+            let title = core::str::from_utf8(msg.title)?;
+
+            if ["fixup!", "squash!", "amend!"]
+                .iter()
+                .any(|p| title.starts_with(p))
+            {
+                // FIXME: Currently, the indent before `git rebase` is not
+                // preserved.
+                bail!(
+                    "Stack contains pending fixup/squash/amend commits.\n\
+                    Please squash your history before syncing:\n\
+                        git rebase -i --autosquash {remote}/{default_branch}",
+                );
+            }
+
+            c.try_into()
+        })
+        .collect()
 }
 
 fn create_gherrit_refs(repo: &util::Repo, commits: Vec<Commit>) -> Result<Vec<Commit>> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -172,7 +172,7 @@ fn install_mock_binaries(path: &Path) {
     fs::copy(&gherrit_bin, &gherrit_dst).unwrap();
 }
 
-fn init_git_bare_repo(path: &Path) {
+pub fn init_git_bare_repo(path: &Path) {
     fs::create_dir(path).unwrap();
     run_git_cmd(path, &["init", "--bare"]);
 }

--- a/tests/pre_push_autosquash.rs
+++ b/tests/pre_push_autosquash.rs
@@ -1,0 +1,187 @@
+// Tests for the detection and rejection of autosquash commits (fixup!, squash!,
+// amend!) in the pre-push hook. These tests ensure that GHerrit prevents users
+// from pushing unfinished work to the remote, maintaining a clean commit
+// history.
+
+mod common;
+use common::TestContext;
+use predicates::prelude::*;
+
+// Helper to assert the specific error message format
+fn assert_autosquash_error(
+    output: assert_cmd::assert::Assert,
+    remote: &str,
+    branch: &str,
+) -> assert_cmd::assert::Assert {
+    output
+        .failure()
+        .stderr(predicate::str::contains(
+            "Stack contains pending fixup/squash/amend commits",
+        ))
+        .stderr(predicate::str::contains(format!(
+            "git rebase -i --autosquash {remote}/{branch}",
+        )))
+}
+
+#[test]
+fn test_autosquash_prefixes() {
+    // Verify that the pre-push hook detects and rejects commits with any of the
+    // standard autosquash prefixes: "fixup!", "squash!", and "amend!". This
+    // ensures that even if a user creates these commits manually or via other
+    // tools, GHerrit will catch them before they reach the remote.
+
+    let ctx = TestContext::init_and_install_hooks();
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Initial"]);
+
+    let prefixes = ["fixup!", "squash!", "amend!"];
+
+    for prefix in prefixes {
+        // Create a new branch for each prefix test to ensure clean state
+        let branch_name = format!("feature-{}", prefix.replace("!", ""));
+        ctx.run_git(&["checkout", "-b", &branch_name, "main"]);
+
+        // Normal commit
+        ctx.run_git(&["commit", "--allow-empty", "-m", "Work in progress"]);
+
+        // Prefix commit
+        ctx.run_git(&[
+            "commit",
+            "--allow-empty",
+            "-m",
+            &format!("{} Work in progress", prefix),
+        ]);
+
+        let output = ctx.gherrit().args(["hook", "pre-push"]).assert();
+        assert_autosquash_error(output, "origin", "main");
+    }
+}
+
+#[test]
+fn test_buried_autosquash_commit() {
+    // Test that the hook scans the entire stack of commits being pushed, not
+    // just the check-out tip.
+    //
+    // In this scenario:
+    // - Commit A (Base)
+    // - Commit B (Dirty - fixup! Commit A) <--- Should trigger failure
+    // - Commit C (Clean tip)
+    //
+    // Even though HEAD (Commit C) is clean, the push includes Commit B, so it
+    // must fail.
+    let ctx = TestContext::init_and_install_hooks();
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Initial"]);
+
+    ctx.run_git(&["checkout", "-b", "feature-buried"]);
+
+    // 1. Commit A
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Commit A"]);
+
+    // 2. Commit B (Dirty)
+    ctx.run_git(&["commit", "--allow-empty", "-m", "fixup! Commit A"]);
+
+    // 3. Commit C (Normal)
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Commit C"]);
+
+    let output = ctx.gherrit().args(["hook", "pre-push"]).assert();
+    assert_autosquash_error(output, "origin", "main");
+}
+
+#[test]
+fn test_precedence_over_trailer_check() {
+    // Test the edge case where a commit implies two conflicting states:
+    // 1. It has a valid `gherrit-pr-id` trailer (usually allowing the push).
+    // 2. It has a `fixup!` prefix (absolutely forbidding the push).
+    //
+    // The autosquash check must take precedence. A "fixup" commit is by
+    // definition temporary/incomplete, so it doesn't matter if it has a valid
+    // ID or not.
+
+    let ctx = TestContext::init_and_install_hooks();
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Initial"]);
+    ctx.run_git(&["checkout", "-b", "feature-precedence"]);
+
+    // Create a fixup commit that ALSO has a valid trailer. Normally, a trailer
+    // makes a commit valid for Gherrit. But 'fixup!' should still block it
+    // because it's considered "work in progress/to be squashed".
+    let msg = "fixup! Some feature\n\ngherrit-pr-id: G12345";
+    ctx.run_git(&["commit", "--allow-empty", "-m", msg]);
+
+    let output = ctx.gherrit().args(["hook", "pre-push"]).assert();
+
+    // Must fail with autosquash error, NOT missing trailer error
+    let output = assert_autosquash_error(output, "origin", "main");
+
+    let stderr = std::str::from_utf8(&output.get_output().stderr).unwrap();
+    assert!(
+        !stderr.contains("missing gherrit-pr-id trailer"),
+        "Error should not be about missing trailer. Got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_dynamic_remote_and_branch_suggestion() {
+    // Test that the error message correctly suggests the command to run even
+    // when the user has a non-standard configuration.
+    // - Remote: "upstream" (instead of "origin")
+    // - Branch: "master" (instead of "main")
+    //
+    // The error message should recommend:
+    //
+    //   git rebase -i --autosquash upstream/master
+
+    let ctx = TestContext::init();
+
+    // Configure default branch to be 'master' to test dynamic branch name
+    // detection.
+    //
+    // Note: `init_with_repo` usually sets main; this renaming operation
+    // ensures that it is `master` *and* should work even if `init_with_repo`
+    // changes to a different default branch name in the future.
+    //
+    // We also explicitly set `init.defaultBranch` to `master` so that Gherrit's
+    // heuristic (which reads this config) finds `master` even if the user has
+    // a global config setting it to `main`.
+    ctx.run_git(&["config", "init.defaultBranch", "master"]);
+    ctx.run_git(&["branch", "-m", "master"]);
+
+    // Add custom remote 'upstream'. We need to actually point it somewhere
+    // valid for `rev-parse` checks if they happen, but the error message
+    // generation just calls `default_remote_name`. However, `gherrit` manages
+    // `origin` by default. We need to tell it to use `upstream`.
+    let upstream_path = ctx.dir.path().join("upstream.git");
+    common::init_git_bare_repo(&upstream_path);
+    ctx.run_git(&["remote", "add", "upstream", upstream_path.to_str().unwrap()]);
+
+    // Configure gherrit to use upstream
+    ctx.run_git(&["config", "gherrit.remote", "upstream"]);
+
+    // Install hooks manually since we didn't use init_and_install_hooks
+    ctx.install_hooks();
+
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Initial"]);
+    ctx.run_git(&["checkout", "-b", "feature-dynamic"]);
+
+    // Create fixup
+    ctx.run_git(&["commit", "--allow-empty", "-m", "fixup! Work"]);
+
+    let output = ctx.gherrit().args(["hook", "pre-push"]).assert();
+
+    assert_autosquash_error(output, "upstream", "master");
+}
+
+#[test]
+fn test_valid_stack_passes() {
+    // Control group test: standard, valid commits should pass without issues.
+
+    let ctx = TestContext::init_and_install_hooks();
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Initial"]);
+    ctx.run_git(&["checkout", "-b", "feature-valid"]);
+
+    // Stack of 3 normal commits
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Commit A"]);
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Commit B"]);
+    ctx.run_git(&["commit", "--allow-empty", "-m", "Commit C"]);
+
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

During the `pre-push` hook, detect commits which start with the prefixes
`fixup!`, `squash!`, or `amend!`, and bail with a helpful error message.

Closes #204




---

- #208


**Latest Update:** v7 — [Compare vs v6](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v6..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v7)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 | v6 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v7 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v7) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v1..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v7) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v2..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v7) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v3..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v7) | [vs v4](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v4..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v7) | [vs v5](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v5..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v7) | [vs v6](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v6..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v7) |
| v6 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v6) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v1..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v6) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v2..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v6) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v3..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v6) | [vs v4](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v4..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v6) | [vs v5](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v5..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v6) | |
| v5 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v5) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v1..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v5) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v2..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v5) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v3..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v5) | [vs v4](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v4..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v5) | | |
| v4 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v4) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v1..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v4) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v2..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v4) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v3..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v4) | | | |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v1..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v2..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v3) | | | | |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v1..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v2) | | | | | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5/v1) | | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "Gc8c8d9d746780ae2091c6b60ddb3ac63ce871be5", "parent": null, "child": null} -->