### PR TITLE
[test] Factor out and simplify common patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "testutil",
 ]
 
 [[package]]
@@ -2054,6 +2055,18 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testutil"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "once_cell",
+ "predicates",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 predicates = "3.1"
 fastrand = "2.0"
+testutil = { path = "testutil" }
 
 [[bin]]
 name = "mock_bin"
 path = "tests/support/mock_bin.rs"
 test = false
+
+[workspace]
+members = ["testutil"]

--- a/tests/reproduce_issue.rs
+++ b/tests/reproduce_issue.rs
@@ -1,6 +1,3 @@
-mod common;
-use common::TestContext;
-
 #[test]
 fn test_special_characters_in_repo_url() {
     // Regression test for #180
@@ -21,12 +18,9 @@ fn test_special_characters_in_repo_url() {
 
     for (user, repo) in scenarios {
         println!("Testing scenario: {user}/{repo}");
-        let ctx = TestContext::init_with_repo(user, repo);
-        ctx.install_hooks();
+        let ctx = testutil::test_context!().owner(user).name(repo).build();
 
-        // Setup a commit
-        ctx.run_git(&["commit", "--allow-empty", "-m", "Initial Commit"]);
-        ctx.run_git(&["checkout", "-b", "feature-stack"]);
+        ctx.checkout_new("feature-stack");
 
         // Manage must happen before commit to ensure the commit-msg hook adds the trailer
         ctx.gherrit().args(["manage"]).assert().success();

--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "testutil"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+assert_cmd = "2.0"
+tempfile = "3.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+predicates = "3.1"
+# For PathBuf and lazy loading usage
+once_cell = "1.19" # Or use std::sync::OnceLock if rust-version supports it (1.70+). 
+# gherrit uses 1.85.0 so we can use std::sync::LazyLock or OnceLock 

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -5,22 +5,91 @@ use std::process::Command;
 use std::sync::LazyLock;
 use tempfile::TempDir;
 
-pub struct TestContext {
-    pub dir: TempDir,
-    pub repo_path: PathBuf,
-    pub remote_path: PathBuf,
-    pub is_live: bool,
-    pub system_git: PathBuf,
+#[macro_export]
+macro_rules! test_context {
+    () => {
+        $crate::TestContextBuilder::new().binaries(
+            assert_cmd::cargo::cargo_bin!("gherrit"),
+            assert_cmd::cargo::cargo_bin!("mock_bin"),
+        )
+    };
 }
 
-#[allow(dead_code)]
-impl TestContext {
-    /// Allocates a new temporary directory and initializes a git repository in it.
-    pub fn init() -> Self {
-        Self::init_with_repo("owner", "repo")
+#[macro_export]
+macro_rules! test_context_minimal {
+    () => {
+        $crate::TestContextBuilder::new_minimal().binaries(
+            assert_cmd::cargo::cargo_bin!("gherrit"),
+            assert_cmd::cargo::cargo_bin!("mock_bin"),
+        )
+    };
+}
+
+pub struct TestContextBuilder {
+    owner: String,
+    name: String,
+    install_hooks: bool,
+    initial_commit: bool,
+    gherrit_bin: Option<PathBuf>,
+    mock_bin: Option<PathBuf>,
+}
+
+impl Default for TestContextBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestContextBuilder {
+    pub fn new() -> Self {
+        Self {
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+            install_hooks: true,
+            initial_commit: true,
+            gherrit_bin: None,
+            mock_bin: None,
+        }
     }
 
-    pub fn init_with_repo(owner: &str, name: &str) -> Self {
+    pub fn new_minimal() -> Self {
+        Self {
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+            install_hooks: false,
+            initial_commit: false,
+            gherrit_bin: None,
+            mock_bin: None,
+        }
+    }
+
+    pub fn binaries(&mut self, gherrit: impl Into<PathBuf>, mock: impl Into<PathBuf>) -> &mut Self {
+        self.gherrit_bin = Some(gherrit.into());
+        self.mock_bin = Some(mock.into());
+        self
+    }
+
+    pub fn owner(&mut self, owner: &str) -> &mut Self {
+        self.owner = owner.to_string();
+        self
+    }
+
+    pub fn name(&mut self, name: &str) -> &mut Self {
+        self.name = name.to_string();
+        self
+    }
+
+    pub fn install_hooks(&mut self, install_hooks: bool) -> &mut Self {
+        self.install_hooks = install_hooks;
+        self
+    }
+
+    pub fn initial_commit(&mut self, initial_commit: bool) -> &mut Self {
+        self.initial_commit = initial_commit;
+        self
+    }
+
+    pub fn build(&self) -> TestContext {
         let dir = TempDir::new().unwrap();
         let repo_path = dir.path().join("local");
         fs::create_dir(&repo_path).unwrap();
@@ -34,36 +103,59 @@ impl TestContext {
         let system_git = SYSTEM_GIT.clone();
 
         init_git_repo(&repo_path, &remote_path);
+
+        let gherrit_bin = self
+            .gherrit_bin
+            .clone()
+            .expect("gherrit binary path must be set");
+        let mock_bin = self.mock_bin.clone().expect("mock binary path must be set");
+
+        let ctx = TestContext {
+            dir,
+            repo_path,
+            remote_path: remote_path.clone(),
+            is_live,
+            system_git: system_git.clone(),
+            gherrit_bin_path: gherrit_bin.clone(),
+        };
+
         if !is_live {
-            install_mock_binaries(dir.path());
+            install_mock_binaries(ctx.dir.path(), &mock_bin, &gherrit_bin);
             // Create initial mock state with custom repo
             let state = MockState {
-                repo_owner: owner.to_string(),
-                repo_name: name.to_string(),
+                repo_owner: self.owner.clone(),
+                repo_name: self.name.clone(),
                 ..Default::default()
             };
             let state_json = serde_json::to_string(&state).unwrap();
-            fs::write(repo_path.join("mock_state.json"), state_json).unwrap();
+            fs::write(ctx.repo_path.join("mock_state.json"), state_json).unwrap();
         }
 
-        Self {
-            dir,
-            repo_path,
-            remote_path,
-            is_live,
-            system_git,
+        if self.install_hooks {
+            ctx.install_hooks();
         }
-    }
 
-    pub fn init_and_install_hooks() -> Self {
-        let ctx = Self::init();
-        ctx.install_hooks();
+        if self.initial_commit {
+            ctx.commit("Initial commit");
+        }
+
         ctx
     }
+}
 
+pub struct TestContext {
+    pub dir: TempDir,
+    pub repo_path: PathBuf,
+    pub remote_path: PathBuf,
+    pub is_live: bool,
+    pub system_git: PathBuf,
+    pub gherrit_bin_path: PathBuf,
+}
+
+impl TestContext {
     pub fn gherrit(&self) -> assert_cmd::Command {
-        let bin_path = env!("CARGO_BIN_EXE_gherrit");
-        let mut cmd = assert_cmd::Command::new(bin_path);
+        // Use injected binary path
+        let mut cmd = assert_cmd::Command::new(&self.gherrit_bin_path);
         cmd.current_dir(&self.repo_path);
 
         if !self.is_live {
@@ -123,6 +215,14 @@ impl TestContext {
         // Use the new install command
         self.gherrit().args(["install"]).assert().success();
     }
+
+    pub fn commit(&self, msg: &str) {
+        self.run_git(&["commit", "--allow-empty", "-m", msg]);
+    }
+
+    pub fn checkout_new(&self, branch_name: &str) {
+        self.run_git(&["checkout", "-b", branch_name]);
+    }
 }
 
 fn run_git_cmd(path: &Path, args: &[&str]) {
@@ -148,17 +248,13 @@ pub struct MockState {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-#[allow(dead_code)]
 pub struct PrEntry {
     pub number: usize,
     pub title: String,
     pub body: String,
 }
 
-fn install_mock_binaries(path: &Path) {
-    let mock_bin = PathBuf::from(env!("CARGO_BIN_EXE_mock_bin"));
-    let gherrit_bin = PathBuf::from(env!("CARGO_BIN_EXE_gherrit"));
-
+pub fn install_mock_binaries(path: &Path, mock_bin: &Path, gherrit_bin: &Path) {
     let git_dst = path.join(if cfg!(windows) { "git.exe" } else { "git" });
     let gh_dst = path.join(if cfg!(windows) { "gh.exe" } else { "gh" });
     let gherrit_dst = path.join(if cfg!(windows) {
@@ -167,9 +263,9 @@ fn install_mock_binaries(path: &Path) {
         "gherrit"
     });
 
-    fs::copy(&mock_bin, &git_dst).unwrap();
-    fs::copy(&mock_bin, &gh_dst).unwrap();
-    fs::copy(&gherrit_bin, &gherrit_dst).unwrap();
+    fs::copy(mock_bin, &git_dst).unwrap();
+    fs::copy(mock_bin, &gh_dst).unwrap();
+    fs::copy(gherrit_bin, &gherrit_dst).unwrap();
 }
 
 pub fn init_git_bare_repo(path: &Path) {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

- Add helpers for committing and for creating branches
- Standardize on "Initial commit" for initial commit message
- Remove unnecessary `gherrit manage` calls
- Introduce `TestContextBuilder` to handle common initialization
  patterns
- Migrate common utilities to a separate crate




---

- #211


**Latest Update:** v4 — [Compare vs v3](https://github.com/joshlf/gherrit/compare/gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v3..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 |
| :--- | :--- | :--- | :--- | :--- |
| v4 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v4) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v1..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v4) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v2..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v4) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v3..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v4) |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v1..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v2..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v3) | |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v1..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v2) | | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G2ccd590afb7660fc311d095a9e7eb26735852948/v1) | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G2ccd590afb7660fc311d095a9e7eb26735852948", "parent": null, "child": null} -->