### PR TITLE
[test] Skip test_install_read_only_fs as root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "eyre",
  "fastrand",
  "gix",
+ "libc",
  "log",
  "owo-colors",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0"
 predicates = "3.1"
 fastrand = "2.0"
 testutil = { path = "testutil" }
+libc = "0.2"
 
 [[bin]]
 name = "mock_bin"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -743,6 +743,13 @@ fn test_pre_push_failure() {
 #[cfg(unix)]
 fn test_install_read_only_fs() {
     use std::os::unix::fs::PermissionsExt as _;
+
+    // Skip if running as root, as root ignores permissions. This can arise in
+    // practice when developing inside a container.
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
     let ctx = testutil::test_context_minimal!().build();
     let hooks_dir = ctx.repo_path.join(".git/hooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

When running as root (e.g. in a development container),
`test_install_read_only_fs` spuriously succeeds, so instead we just
detect running as root and skip it in that case.




---

- #216
- #215


**Latest Update:** v2 — [Compare vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G11f921da075dc1d976e2cbf092dfc5d8f68b8726/v1..gherrit/G11f921da075dc1d976e2cbf092dfc5d8f68b8726/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 |
| :--- | :--- | :--- |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G11f921da075dc1d976e2cbf092dfc5d8f68b8726/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G11f921da075dc1d976e2cbf092dfc5d8f68b8726/v1..gherrit/G11f921da075dc1d976e2cbf092dfc5d8f68b8726/v2) |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G11f921da075dc1d976e2cbf092dfc5d8f68b8726/v1) | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G11f921da075dc1d976e2cbf092dfc5d8f68b8726", "parent": null, "child": "G4f2e918a4cb090957ae8f644db26fa86154f09fc"} -->