### PR TITLE
Rationalize branch config management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gherrit"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.89.0"
 
 [profile.release]
 debug = true

--- a/src/commit_msg.rs
+++ b/src/commit_msg.rs
@@ -21,7 +21,6 @@
 use std::fs;
 use std::path::Path;
 
-use crate::manage;
 use crate::{cmd, util};
 use eyre::{Result, WrapErr, bail};
 use owo_colors::OwoColorize;
@@ -35,16 +34,14 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
         bail!("File does not exist: {}", msg_path.display().red().bold());
     }
 
-    // Get current branch (Supporting Rebase)
+    // Get current branch (supporting rebase)
     let Some(branch_name) = repo.current_branch().name() else {
         log::debug!("Could not determine branch name (detached head?). Skipping.");
         return Ok(());
     };
 
-    // Check if managed – bail if unmanaged or if management state is unset.
-    if manage::get_state(repo, branch_name).wrap_err("Failed to get config")?
-        != Some(manage::State::Managed)
-    {
+    if !repo.is_managed(branch_name)? {
+        log::warn!("Branch {} is not managed. Skipping.", branch_name.yellow());
         return Ok(());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,10 @@ mod manage;
 mod pre_push;
 mod util;
 
+use clap::{Parser, Subcommand};
 use eyre::{Result, WrapErr};
 
-use clap::{Parser, Subcommand};
+use manage::State;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -21,9 +22,25 @@ enum Commands {
     #[command(subcommand, hide = true)]
     Hook(HookCommands),
     /// Configure the current branch to be managed by GHerrit.
-    Manage,
+    Manage {
+        /// Force the configuration update, overwriting any manual changes.
+        #[arg(long, short)]
+        force: bool,
+
+        /// Configure the branch to be public (`git push` syncs PRs *and* pushes the branch itself).
+        #[arg(long, group = "visibility")]
+        public: bool,
+
+        /// Configure the branch to be private (`git push` syncs PRs *only*; does not push the branch itself).
+        #[arg(long, group = "visibility")]
+        private: bool,
+    },
     /// Configure the current branch to be unmanaged by GHerrit.
-    Unmanage,
+    Unmanage {
+        /// Force the configuration update, overwriting any manual changes.
+        #[arg(long, short)]
+        force: bool,
+    },
     /// Install GHerrit Git hooks.
     Install {
         /// Overwrite existing hooks not managed by GHerrit
@@ -113,8 +130,27 @@ fn run() -> Result<()> {
             }
             HookCommands::CommitMsg { file } => commit_msg::run(&repo, &file)?,
         },
-        Commands::Manage => manage::set_state(&repo, manage::State::Managed)?,
-        Commands::Unmanage => manage::set_state(&repo, manage::State::Unmanaged)?,
+        Commands::Manage {
+            force,
+            public,
+            private,
+        } => {
+            let target_state = if public {
+                State::Public
+            } else if private {
+                State::Private
+            } else {
+                // If no flag provided, preserve current state (enforcing config) or default to private.
+                let (_, state) = repo.read_current_branch_and_state()?;
+                match state {
+                    Some(State::Public) => State::Public,
+                    Some(State::Private) => State::Private,
+                    Some(State::Unmanaged) | None => State::Private,
+                }
+            };
+            manage::set_state(&repo, target_state, force)?
+        }
+        Commands::Unmanage { force } => manage::set_state(&repo, State::Unmanaged, force)?,
         Commands::Install {
             force,
             allow_global,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,11 @@
 use std::ffi::OsStr;
 use std::process::Command;
 
-use eyre::{OptionExt, Result};
+use eyre::{OptionExt, Result, bail};
 use gix::bstr::ByteSlice;
 use gix::state::InProgress;
+
+use crate::manage::State;
 
 /// Constructs a `std::process::Command`.
 ///
@@ -138,10 +140,6 @@ impl Repo {
         Ok(Some(s.trim().to_string()))
     }
 
-    pub fn config_bool(&self, key: &str) -> Result<Option<bool>> {
-        Ok(self.inner.config_snapshot().try_boolean(key).transpose()?)
-    }
-
     pub fn config_path(&self, key: &str) -> Result<Option<PathBuf>> {
         let snapshot = self.inner.config_snapshot();
         let Some(path_val) = snapshot.path(key) else {
@@ -250,6 +248,34 @@ impl Repo {
         let branches = self.find_default_branches(&self.default_remote_name());
         branches.iter().any(|b| b == branch_name)
     }
+
+    // Check whether the branch is managed by GHerrit.
+    pub fn is_managed(&self, branch_name: &str) -> Result<bool> {
+        match State::read_from(self, branch_name)? {
+            Some(State::Unmanaged) => Ok(false),
+            Some(State::Private | State::Public) => Ok(true),
+            None => {
+                bail!(
+                    "It is unclear whether branch '{branch_name}' should be managed by GHerrit.\n\
+                    Run 'gherrit manage' to sync it as a GHerrit stack.\n\
+                    Run 'gherrit unmanage' to push it as a standard Git branch."
+                );
+            }
+        }
+    }
+
+    pub fn read_current_branch_and_state(&self) -> Result<(String, Option<State>)> {
+        let branch_name = self.current_branch();
+        let branch_name = match branch_name {
+            HeadState::Attached(bn) | HeadState::Pending(bn) => bn,
+            HeadState::Detached => {
+                bail!("Cannot get management state in detached HEAD");
+            }
+        };
+
+        let state = State::read_from(self, branch_name)?;
+        Ok((branch_name.clone(), state))
+    }
 }
 
 impl std::ops::Deref for Repo {
@@ -294,6 +320,20 @@ fn get_current_branch(repo: &gix::Repository) -> Result<HeadState> {
     }
 
     Ok(HeadState::Detached)
+}
+
+pub trait CommandExt {
+    fn success(&mut self) -> Result<()>;
+}
+
+impl CommandExt for Command {
+    fn success(&mut self) -> Result<()> {
+        let status = self.status()?;
+        if !status.success() {
+            bail!("Command failed with status: {}", status);
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/tests/branch_config_transitions.rs
+++ b/tests/branch_config_transitions.rs
@@ -1,0 +1,230 @@
+use testutil::TestContext;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum StartState {
+    /// gherritManaged is false/unset, and all relevant git configs are unset/default.
+    UnmanagedClean,
+    /// gherritManaged is false/unset, but configs have been manually set (e.g., pushRemote=dirty-remote).
+    UnmanagedDirty,
+    /// gherritManaged is managedPrivate, and configs match the expected private state (pushRemote=.).
+    PrivateClean,
+    /// gherritManaged is managedPrivate, but configs do NOT match (e.g., pushRemote=drifted-remote).
+    PrivateDrifted,
+    /// gherritManaged is managedPublic, and configs match the expected public state (pushRemote=origin).
+    PublicClean,
+    /// gherritManaged is managedPublic, but configs do NOT match (e.g., pushRemote=drifted-remote).
+    PublicDrifted,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Command {
+    ManageDefault,
+    ManagePrivate,
+    ManagePublic,
+    Unmanage,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ExpectedResult {
+    Success,
+    Block,
+}
+
+struct TestCase {
+    id: &'static str,
+    start: StartState,
+    cmd: Command,
+    force: bool,
+    expected_result: ExpectedResult,
+    expected_final_state: StartState,
+}
+
+const BRANCH: &str = "feature";
+const MANAGE_PRIVATE: &str = "managedPrivate";
+const MANAGE_PUBLIC: &str = "managedPublic";
+
+/// Helper to force the repo into a specific state
+fn setup_state(ctx: &TestContext, state: StartState) {
+    // Always start with a clean branch
+    let _ = ctx.git().args(["branch", "-D", BRANCH]).output();
+    ctx.checkout_new(BRANCH);
+
+    let set_config = |key: &str, val: &str| {
+        ctx.run_git(&["config", key, val]);
+    };
+    let unset_config = |key: &str| {
+        let _ = ctx.git().args(["config", "--unset", key]).ok();
+    };
+
+    let key_managed = format!("branch.{BRANCH}.gherritManaged");
+    let key_push = format!("branch.{BRANCH}.pushRemote");
+    let key_remote = format!("branch.{BRANCH}.remote");
+    let key_merge = format!("branch.{BRANCH}.merge");
+
+    match state {
+        StartState::UnmanagedClean => {
+            unset_config(&key_managed);
+            unset_config(&key_push);
+            unset_config(&key_remote);
+            unset_config(&key_merge);
+        }
+        StartState::UnmanagedDirty => {
+            unset_config(&key_managed);
+            set_config(&key_push, "dirty-remote");
+        }
+        StartState::PrivateClean => {
+            set_config(&key_managed, MANAGE_PRIVATE);
+            set_config(&key_push, ".");
+            set_config(&key_remote, ".");
+            set_config(&key_merge, &format!("refs/heads/{BRANCH}"));
+        }
+        StartState::PrivateDrifted => {
+            set_config(&key_managed, MANAGE_PRIVATE);
+            set_config(&key_push, "drifted-remote");
+            set_config(&key_remote, ".");
+            set_config(&key_merge, &format!("refs/heads/{BRANCH}"));
+        }
+        StartState::PublicClean => {
+            set_config(&key_managed, MANAGE_PUBLIC);
+            set_config(&key_push, "origin");
+            set_config(&key_remote, ".");
+            set_config(&key_merge, &format!("refs/heads/{BRANCH}"));
+        }
+        StartState::PublicDrifted => {
+            set_config(&key_managed, MANAGE_PUBLIC);
+            set_config(&key_push, "drifted-remote");
+            set_config(&key_remote, ".");
+            set_config(&key_merge, &format!("refs/heads/{BRANCH}"));
+        }
+    }
+}
+
+fn verify_state(ctx: &TestContext, expected: StartState) {
+    let get_config = |key: &str| -> Option<String> {
+        let output = ctx.git().args(["config", key]).output().ok()?;
+        if output.status.success() {
+            Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            None
+        }
+    };
+
+    let val_managed = get_config(&format!("branch.{BRANCH}.gherritManaged"));
+    let val_push = get_config(&format!("branch.{BRANCH}.pushRemote"));
+
+    match expected {
+        StartState::UnmanagedClean => {
+            assert_eq!(val_managed.as_deref().unwrap_or("false"), "false");
+            assert!(val_push.is_none(), "Expected pushRemote to be unset");
+        }
+        StartState::UnmanagedDirty => {
+            assert_eq!(val_managed.as_deref().unwrap_or("false"), "false");
+            assert_eq!(val_push.as_deref(), Some("dirty-remote"));
+        }
+        StartState::PrivateClean => {
+            assert_eq!(val_managed.as_deref(), Some(MANAGE_PRIVATE));
+            assert_eq!(val_push.as_deref(), Some("."));
+        }
+        StartState::PrivateDrifted => {
+            assert_eq!(val_managed.as_deref(), Some(MANAGE_PRIVATE));
+            assert_eq!(val_push.as_deref(), Some("drifted-remote"));
+        }
+        StartState::PublicClean => {
+            assert_eq!(val_managed.as_deref(), Some(MANAGE_PUBLIC));
+            assert_eq!(val_push.as_deref(), Some("origin"));
+        }
+        StartState::PublicDrifted => {
+            assert_eq!(val_managed.as_deref(), Some(MANAGE_PUBLIC));
+            assert_eq!(val_push.as_deref(), Some("drifted-remote"));
+        }
+    }
+}
+
+#[test]
+fn test_branch_config_transitions() {
+    #[rustfmt::skip]
+    let cases = {
+        use {Command::*, ExpectedResult::*, StartState::*};
+
+        vec![
+            // Unmanaged Clean -> ...
+            TestCase { id: "T01", start: UnmanagedClean, cmd: ManageDefault, force: false, expected_result: Success, expected_final_state: PrivateClean },
+            TestCase { id: "T02", start: UnmanagedClean, cmd: ManagePublic, force: false, expected_result: Success, expected_final_state: PublicClean },
+            TestCase { id: "T03", start: UnmanagedClean, cmd: Unmanage, force: false, expected_result: Success, expected_final_state: UnmanagedClean },
+
+            // Unmanaged Dirty -> ...
+            TestCase { id: "T04", start: UnmanagedDirty, cmd: ManagePrivate, force: false, expected_result: Block, expected_final_state: UnmanagedDirty },
+            TestCase { id: "T05", start: UnmanagedDirty, cmd: ManagePrivate, force: true, expected_result: Success, expected_final_state: PrivateClean },
+            TestCase { id: "T06", start: UnmanagedDirty, cmd: ManagePublic, force: false, expected_result: Block, expected_final_state: UnmanagedDirty },
+            TestCase { id: "T07", start: UnmanagedDirty, cmd: ManagePublic, force: true, expected_result: Success, expected_final_state: PublicClean },
+
+            // Private Clean -> ...
+            TestCase { id: "T08", start: PrivateClean, cmd: ManagePrivate, force: false, expected_result: Success, expected_final_state: PrivateClean },
+            TestCase { id: "T09", start: PrivateClean, cmd: ManagePublic, force: false, expected_result: Success, expected_final_state: PublicClean },
+            TestCase { id: "T10", start: PrivateClean, cmd: Unmanage, force: false, expected_result: Success, expected_final_state: UnmanagedClean },
+
+            // Private Drifted -> ...
+            TestCase { id: "T11", start: PrivateDrifted, cmd: ManagePrivate, force: false, expected_result: Block, expected_final_state: PrivateDrifted },
+            TestCase { id: "T12", start: PrivateDrifted, cmd: ManagePrivate, force: true, expected_result: Success, expected_final_state: PrivateClean },
+            TestCase { id: "T13", start: PrivateDrifted, cmd: ManagePublic, force: false, expected_result: Block, expected_final_state: PrivateDrifted },
+            TestCase { id: "T14", start: PrivateDrifted, cmd: ManagePublic, force: true, expected_result: Success, expected_final_state: PublicClean },
+            TestCase { id: "T15", start: PrivateDrifted, cmd: Unmanage, force: false, expected_result: Block, expected_final_state: PrivateDrifted },
+            TestCase { id: "T16", start: PrivateDrifted, cmd: Unmanage, force: true, expected_result: Success, expected_final_state: UnmanagedClean },
+
+            // Public Clean -> ...
+            TestCase { id: "T17", start: PublicClean, cmd: ManagePrivate, force: false, expected_result: Success, expected_final_state: PrivateClean },
+            TestCase { id: "T18", start: PublicClean, cmd: ManagePublic, force: false, expected_result: Success, expected_final_state: PublicClean },
+            TestCase { id: "T19", start: PublicClean, cmd: Unmanage, force: false, expected_result: Success, expected_final_state: UnmanagedClean },
+
+            // Public Drifted -> ...
+            TestCase { id: "T20", start: PublicDrifted, cmd: ManagePrivate, force: false, expected_result: Block, expected_final_state: PublicDrifted },
+            TestCase { id: "T21", start: PublicDrifted, cmd: ManagePrivate, force: true, expected_result: Success, expected_final_state: PrivateClean },
+            TestCase { id: "T22", start: PublicDrifted, cmd: ManagePublic, force: false, expected_result: Block, expected_final_state: PublicDrifted },
+            TestCase { id: "T23", start: PublicDrifted, cmd: ManagePublic, force: true, expected_result: Success, expected_final_state: PublicClean },
+            TestCase { id: "T24", start: PublicDrifted, cmd: Unmanage, force: false, expected_result: Block, expected_final_state: PublicDrifted },
+            TestCase { id: "T25", start: PublicDrifted, cmd: Unmanage, force: true, expected_result: Success, expected_final_state: UnmanagedClean },
+        ]
+    };
+
+    let ctx = testutil::test_context_minimal!().build();
+
+    for case in cases {
+        println!("Running Case: {}", case.id);
+        setup_state(&ctx, case.start);
+
+        let mut cmd = ctx.gherrit();
+        match case.cmd {
+            Command::ManageDefault => {
+                cmd.arg("manage");
+            }
+            Command::ManagePrivate => {
+                cmd.args(["manage", "--private"]);
+            }
+            Command::ManagePublic => {
+                cmd.args(["manage", "--public"]);
+            }
+            Command::Unmanage => {
+                cmd.arg("unmanage");
+            }
+        }
+
+        if case.force {
+            cmd.arg("--force");
+        }
+
+        let assert = cmd.assert().success(); // All these commands should exit 0, even blocks (they just warn)
+        // Check output for blocks
+        if case.expected_result == ExpectedResult::Block {
+            let output = assert.get_output();
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                stderr.contains("drift detected"),
+                "Case {}: Expected warning about drift, got: {}",
+                case.id,
+                stderr
+            );
+        }
+
+        verify_state(&ctx, case.expected_final_state);
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,6 @@
+const MANAGED_PRIVATE: &str = "managedPrivate";
+const MANAGED_PUBLIC: &str = "managedPublic";
+
 #[test]
 fn test_commit_msg_hook() {
     let ctx = testutil::test_context_minimal!().build();
@@ -60,21 +63,29 @@ fn test_branch_management() {
     // Scenario A: Custom Push Remote Preservation
     ctx.run_git(&["config", "branch.feature-A.pushRemote", "origin"]);
 
-    ctx.gherrit().args(["manage"]).assert().success();
+    // Attempt manage - should fail (drift)
+    ctx.gherrit().args(["manage"]).assert().success(); // Logs warning, no change
+    // Assert still unmanaged (missing key)
+    ctx.git()
+        .args(["config", "branch.feature-A.gherritManaged"])
+        .assert()
+        .failure();
+
+    ctx.gherrit().args(["manage", "--force"]).assert().success();
 
     // Assert managed
     ctx.git()
         .args(["config", "branch.feature-A.gherritManaged"])
         .assert()
         .success()
-        .stdout("true\n");
+        .stdout(format!("{}\n", MANAGED_PRIVATE));
 
-    // Assert pushRemote preserved
+    // Assert pushRemote updated to loopback (Private default)
     ctx.git()
         .args(["config", "branch.feature-A.pushRemote"])
         .assert()
         .success()
-        .stdout("origin\n");
+        .stdout(".\n");
 
     // Assert other keys set
     ctx.git()
@@ -108,12 +119,11 @@ fn test_branch_management() {
         .assert()
         .failure();
 
-    // Assert pushRemote preserved
+    // Assert pushRemote unset
     ctx.git()
         .args(["config", "branch.feature-A.pushRemote"])
         .assert()
-        .success()
-        .stdout("origin\n");
+        .failure();
 }
 
 #[test]
@@ -124,19 +134,11 @@ fn test_post_checkout_hook() {
 
     ctx.checkout_new("feature-stack");
 
-    // Manually invoke the hook (Simulation of git calling it)
-    // args: prev_sha new_sha flag(1=branch checkout)
-    ctx.gherrit()
-        .args(["hook", "post-checkout", "HEAD", "HEAD", "1"])
-        .assert()
-        .success();
-
-    // Assert managed = true
     ctx.git()
         .args(["config", "branch.feature-stack.gherritManaged"])
         .assert()
         .success()
-        .stdout("true\n");
+        .stdout(format!("{}\n", MANAGED_PRIVATE));
 
     // Scenario B: Existing Branch
     // ------------------------------------------------
@@ -148,6 +150,7 @@ fn test_post_checkout_hook() {
     ctx.run_git(&["update-ref", "refs/remotes/origin/collab-feature", "HEAD"]);
 
     // Checkout tracking branch atomically so config is set when hook runs
+    // This implicitly runs post-checkout hook.
     ctx.run_git(&[
         "checkout",
         "-b",
@@ -155,12 +158,6 @@ fn test_post_checkout_hook() {
         "--track",
         "origin/collab-feature",
     ]);
-
-    // Manually invoke hook
-    ctx.gherrit()
-        .args(["hook", "post-checkout", "HEAD", "HEAD", "1"])
-        .assert()
-        .success();
 
     // Assert managed = false
     ctx.git()
@@ -510,7 +507,7 @@ fn test_rebase_detection() {
         .args(["config", "branch.feature-rebase.gherritManaged"])
         .assert()
         .success()
-        .stdout("true\n");
+        .stdout(format!("{}\n", MANAGED_PRIVATE));
 }
 
 #[test]
@@ -672,14 +669,20 @@ fn test_manage_detached_head() {
     // Enter detached HEAD state
     ctx.run_git(&["checkout", "--detach"]);
 
-    // Attempt to manage; should fail with specific error
-    ctx.gherrit()
-        .args(["manage"])
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains(
-            "Cannot set state for detached HEAD",
-        ));
+    let test = |args: &[_]| {
+        ctx.gherrit()
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains(
+                "Cannot get management state in detached HEAD",
+            ))
+    };
+
+    test(&["manage"]);
+    test(&["manage", "--public"]);
+    test(&["manage", "--private"]);
+    test(&["unmanage"]);
 }
 
 #[test]
@@ -689,7 +692,11 @@ fn test_unmanage_cleanup_logic() {
     ctx.checkout_new("feature-cleanup");
 
     // Manually configure the state to exact values that trigger the deep cleanup logic
-    ctx.run_git(&["config", "branch.feature-cleanup.gherritManaged", "true"]);
+    ctx.run_git(&[
+        "config",
+        "branch.feature-cleanup.gherritManaged",
+        MANAGED_PRIVATE,
+    ]);
     ctx.run_git(&["config", "branch.feature-cleanup.pushRemote", "."]);
     ctx.run_git(&["config", "branch.feature-cleanup.remote", "."]);
     ctx.run_git(&[
@@ -766,4 +773,177 @@ fn test_install_read_only_fs() {
     let mut perms = std::fs::metadata(&hooks_dir).unwrap().permissions();
     perms.set_mode(0o755);
     std::fs::set_permissions(&hooks_dir, perms).unwrap();
+}
+
+#[test]
+fn test_manage_drift_detection() {
+    let ctx = testutil::test_context_minimal!().build();
+    ctx.checkout_new("drift-feature");
+
+    // 1. Initialize managed private branch
+    ctx.gherrit()
+        .args(["manage", "--private"])
+        .assert()
+        .success();
+
+    // 2. Manually sabotage
+    ctx.run_git(&["config", "branch.drift-feature.pushRemote", "origin"]);
+
+    // 3. Attempt Switch to Public (without force)
+    // The command should exit with 0 but log a warning and NOT apply changes.
+    let output = ctx
+        .gherrit()
+        .args(["manage", "--public"])
+        .assert()
+        .success();
+
+    let stderr = std::str::from_utf8(&output.get_output().stderr).unwrap();
+    assert!(stderr.contains("Configuration drift detected"));
+    assert!(stderr.contains("- pushRemote: current='origin', expected='.'"));
+
+    // Assert state matches OLD state (Private)
+    ctx.git()
+        .args(["config", "branch.drift-feature.gherritManaged"])
+        .assert()
+        .stdout(format!("{}\n", MANAGED_PRIVATE));
+
+    // 4. Force Switch
+    ctx.gherrit()
+        .args(["manage", "--public", "--force"])
+        .assert()
+        .success();
+
+    // Assert Success
+    ctx.git()
+        .args(["config", "branch.drift-feature.gherritManaged"])
+        .assert()
+        .stdout(format!("{}\n", MANAGED_PUBLIC));
+
+    // Check pushRemote is now origin
+    ctx.git()
+        .args(["config", "branch.drift-feature.pushRemote"])
+        .assert()
+        .stdout("origin\n");
+}
+
+#[test]
+fn test_manage_toggle_visibility() {
+    let ctx = testutil::test_context_minimal!().build();
+    ctx.checkout_new("visibility-feature");
+
+    // 1. Private
+    ctx.gherrit()
+        .args(["manage", "--private"])
+        .assert()
+        .success();
+    ctx.git()
+        .args(["config", "branch.visibility-feature.pushRemote"])
+        .assert()
+        .stdout(".\n");
+
+    // 2. Public
+    ctx.gherrit()
+        .args(["manage", "--public"])
+        .assert()
+        .success();
+    ctx.git()
+        .args(["config", "branch.visibility-feature.pushRemote"])
+        .assert()
+        .stdout("origin\n");
+
+    // 3. Private again
+    ctx.gherrit()
+        .args(["manage", "--private"])
+        .assert()
+        .success();
+    ctx.git()
+        .args(["config", "branch.visibility-feature.pushRemote"])
+        .assert()
+        .stdout(".\n");
+}
+
+#[test]
+fn test_manage_mutually_exclusive_flags() {
+    let ctx = testutil::test_context_minimal!().build();
+    ctx.checkout_new("conflict-feature");
+
+    // Attempt to set both flags
+    let assert = ctx
+        .gherrit()
+        .args(["manage", "--public", "--private"])
+        .assert()
+        .failure();
+
+    // Verify error message from clap
+    let output = assert.get_output();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert!(stderr.contains("the argument '--public' cannot be used with '--private'"));
+}
+
+#[test]
+fn test_manage_invalid_config() {
+    let ctx = testutil::test_context_minimal!().build();
+    ctx.checkout_new("invalid-config-feature");
+
+    // Manually set invalid config
+    ctx.run_git(&[
+        "config",
+        "branch.invalid-config-feature.gherritManaged",
+        "bad-value",
+    ]);
+
+    // Attempt to manage; should fail
+    let assert = ctx.gherrit().args(["manage"]).assert().failure();
+
+    let output = assert.get_output();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert!(stderr.contains("Invalid gherritManaged value"));
+    assert!(stderr.contains("bad-value"));
+}
+
+#[test]
+fn test_post_checkout_drift_detection() {
+    let ctx = testutil::test_context!().build();
+
+    // Condition A: Shared Branch Drift (Unmanaged vs Upstream Config)
+    // HEAD Logic: None -> Unmanaged is silent. No warning.
+    ctx.run_git(&["checkout", "main"]);
+    ctx.run_git(&["update-ref", "refs/remotes/origin/drift-shared", "HEAD"]);
+
+    // Switch to new tracking branch - this triggers post-checkout
+    let assert = ctx
+        .git()
+        .args([
+            "checkout",
+            "-b",
+            "drift-shared",
+            "--track",
+            "origin/drift-shared",
+        ])
+        .assert()
+        .success();
+    let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
+    assert!(
+        !stderr.contains("Configuration drift detected"),
+        "Expected NO drift warning for shared branch (silent unmanage)"
+    );
+
+    // Condition B: New Stack Drift (Private vs Pre-existing Config)
+    ctx.run_git(&["checkout", "main"]);
+    ctx.run_git(&["branch", "drift-stack"]);
+    // Sabotage: Set remote=origin for what SHOULD be a private stack
+    ctx.run_git(&["config", "branch.drift-stack.remote", "origin"]);
+
+    // Switch to it
+    let assert = ctx
+        .git()
+        .args(["checkout", "drift-stack"])
+        .assert()
+        .success();
+    let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
+    assert!(
+        stderr.contains("Configuration drift detected"),
+        "Expected drift warning for new stack"
+    );
+    assert!(stderr.contains("- remote: current='origin', expected='<unset>'"));
 }

--- a/tests/reproduce_unmanaged_sync.rs
+++ b/tests/reproduce_unmanaged_sync.rs
@@ -1,0 +1,53 @@
+use testutil::test_context_minimal;
+
+#[test]
+fn test_reproduce_unmanaged_sync() {
+    // Prior to #217 (G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e), we didn't
+    // consistently distinguish between a missing `gherritManaged` configuration
+    // and `gherritManaged = unmanaged`. We also spuriously synced
+    // unmanaged branches. This is a regression test for the latter bug.
+
+    let ctx = test_context_minimal!().install_hooks(true).build();
+
+    // Condition 1: Explicit Unmanaged
+    ctx.checkout_new("explicit-unmanaged");
+    ctx.run_git(&[
+        "config",
+        "branch.explicit-unmanaged.gherritManaged",
+        "false",
+    ]);
+    ctx.commit("Explicit Commit");
+
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+
+    let state = ctx.read_mock_state();
+    assert!(
+        state.prs.is_empty(),
+        "Explicit unmanaged branch should NOT sync PRs. Found: {:?}",
+        state.prs
+    );
+
+    // Condition 2: Implicit Unmanaged
+    ctx.checkout_new("implicit-unmanaged");
+    ctx.run_git(&[
+        "config",
+        "--unset",
+        "branch.implicit-unmanaged.gherritManaged",
+    ]);
+    ctx.run_git(&[
+        "commit",
+        "--allow-empty",
+        "-m",
+        "Implicit Commit",
+        "--no-verify",
+    ]);
+
+    let _ = ctx.gherrit().args(["hook", "pre-push"]).output().unwrap();
+
+    let state = ctx.read_mock_state();
+    assert!(
+        state.prs.is_empty(),
+        "Implicit unmanaged branch should NOT sync PRs. Found: {:?}",
+        state.prs
+    );
+}

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -281,6 +281,8 @@ fn init_git_repo(path: &Path, remote_path: &Path) {
     run_git_cmd(path, &["config", "user.name", "Test User"]);
     // Ensure default branch is main
     run_git_cmd(path, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+    // Explicitly unmanage main to satisfy strict config checks
+    run_git_cmd(path, &["config", "branch.main.gherritManaged", "false"]);
     // Add origin remote
     run_git_cmd(
         path,


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Instead of encouraging users to manually manipulate git config values
directly, provide high-level commands which do this for them. In
particular:
- `gherrit unmanage`
- `gherrit manage`
- `gherrit manage [--public | --private]`

These commands now check to see whether the *existing* (ie, old)
configuration is internally-consistent. If not, the operation will fail
rather than risk overwriting customized configuration values. A
`--force` flag can be passed to override this behavior.

Closes #201




---

- #217


**Latest Update:** v19 — [Compare vs v18](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 | v6 | v7 | v8 | v9 | v10 | v11 | v12 | v13 | v14 | v15 | v16 | v17 | v18 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v19 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v11](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v12](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v13](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v14](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v15](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v16](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v17](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) | [v18](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v19) |
| v18 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v11](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v12](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v13](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v14](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v15](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v16](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | [v17](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v18) | |
| v17 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v11](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v12](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v13](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v14](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v15](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | [v16](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v17) | | |
| v16 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v11](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v12](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v13](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v14](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | [v15](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v16) | | | |
| v15 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v11](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v12](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v13](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | [v14](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v15) | | | | |
| v14 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v11](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v12](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | [v13](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v14) | | | | | |
| v13 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v11](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | [v12](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v13) | | | | | | |
| v12 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | [v11](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v12) | | | | | | | |
| v11 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | [v10](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v11) | | | | | | | | |
| v10 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | [v9](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v10) | | | | | | | | | |
| v9 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | [v8](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v9) | | | | | | | | | | |
| v8 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8) | [v7](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v8) | | | | | | | | | | | |
| v7 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7) | [v6](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v7) | | | | | | | | | | | | |
| v6 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6) | [v5](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v6) | | | | | | | | | | | | | |
| v5 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5) | [v4](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v5) | | | | | | | | | | | | | | |
| v4 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4) | [v3](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v4) | | | | | | | | | | | | | | | |
| v3 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3) | [v2](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v3) | | | | | | | | | | | | | | | | |
| v2 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2) | [v1](https://github.com/joshlf/gherrit/compare/gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v2) | | | | | | | | | | | | | | | | | |
| v1 | [Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e/v1) | | | | | | | | | | | | | | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G1819a33e08a05c90e7f5e7a6198cd8ad7ca7e76e", "parent": null, "child": null} -->