### PR TITLE
Upgrade cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
+checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -1576,9 +1576,9 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -1587,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b484ba8d4f775eeca644c452a56650e544bf7e617f1d170fe7298122ead5222"
+checksum = "15413ef615ad868d4d65dce091cb233b229419c7c0c4bcaa746c0901c49ff39c"
 dependencies = [
  "zlib-rs",
 ]
@@ -1980,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "signal-hook"
@@ -2062,7 +2062,6 @@ name = "testutil"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
- "once_cell",
  "predicates",
  "serde",
  "serde_json",
@@ -2373,6 +2372,6 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36134c44663532e6519d7a6dfdbbe06f6f8192bde8ae9ed076e9b213f0e31df7"
+checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ serde = { version = "1.0.228", features = ["serde_derive"] }
 serde_json = "1.0.145"
 log = "0.4"
 env_logger = "0.11"
-clap = { version = "4.5.21", features = ["derive"] }
+clap = { version = "4.5.53", features = ["derive"] }
 eyre = "0.6"
 color-eyre = "0.6"
-owo-colors = "4.0"
+owo-colors = "4.2"
 
 [dev-dependencies]
-assert_cmd = "2.0"
-tempfile = "3.10"
+assert_cmd = "2.1"
+tempfile = "3.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 predicates = "3.1"
-fastrand = "2.0"
+fastrand = "2.3"
 testutil = { path = "testutil" }
 libc = "0.2"
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -906,7 +906,6 @@ fn test_post_checkout_drift_detection() {
     let ctx = testutil::test_context!().build();
 
     // Condition A: Shared Branch Drift (Unmanaged vs Upstream Config)
-    // HEAD Logic: None -> Unmanaged is silent. No warning.
     ctx.run_git(&["checkout", "main"]);
     ctx.run_git(&["update-ref", "refs/remotes/origin/drift-shared", "HEAD"]);
 

--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -4,11 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-assert_cmd = "2.0"
-tempfile = "3.10"
+assert_cmd = "2.1"
+tempfile = "3.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 predicates = "3.1"
-# For PathBuf and lazy loading usage
-once_cell = "1.19" # Or use std::sync::OnceLock if rust-version supports it (1.70+). 
-# gherrit uses 1.85.0 so we can use std::sync::LazyLock or OnceLock 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #222
- #220


**Latest Update:** v5 — [Compare vs v4](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v4..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 |
| :--- | :--- | :--- | :--- | :--- | :--- |
| v5 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v5) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v1..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v5) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v2..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v5) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v3..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v5) | [vs v4](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v4..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v5) |
| v4 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v4) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v1..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v4) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v2..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v4) | [vs v3](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v3..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v4) | |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v1..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v2..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v3) | | |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v1..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v2) | | | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd/v1) | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G0dd96e98b4e22802805b8916ad84d92c9f9c6cdd", "parent": null, "child": "Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5"} -->