### PR TITLE
Improve robustness against command failure

### DIFF
--- a/src/commit_msg.rs
+++ b/src/commit_msg.rs
@@ -21,7 +21,10 @@
 use std::fs;
 use std::path::Path;
 
-use crate::{cmd, util};
+use crate::{
+    cmd,
+    util::{self, CommandExt as _},
+};
 use eyre::{Result, WrapErr, bail};
 use owo_colors::OwoColorize;
 
@@ -61,7 +64,7 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
     // Calculate Change-ID
     // Construct the input: "Ident\nRefHash\nMsgContent"
     let input_data = {
-        let committer_ident = cmd!("git var GIT_COMMITTER_IDENT").output()?;
+        let committer_ident = cmd!("git var GIT_COMMITTER_IDENT").checked_output()?;
         let committer_ident = String::from_utf8_lossy(committer_ident.stdout.as_slice())
             .trim()
             .to_string();
@@ -84,7 +87,7 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
     let random_hash = object_id.to_string();
 
     // Check if trailer exists
-    let output = cmd!("git interpret-trailers --parse", msg_file).output()?;
+    let output = cmd!("git interpret-trailers --parse", msg_file).checked_output()?;
     let trailers = String::from_utf8_lossy(&output.stdout);
 
     let re = crate::re!(r"^gherrit-pr-id: .*");
@@ -100,6 +103,6 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
         "gherrit-pr-id: G{random_hash}",
         msg_file
     )
-    .status()?;
+    .success()?;
     Ok(())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -324,6 +324,7 @@ fn get_current_branch(repo: &gix::Repository) -> Result<HeadState> {
 
 pub trait CommandExt {
     fn success(&mut self) -> Result<()>;
+    fn checked_output(&mut self) -> Result<std::process::Output>;
 }
 
 impl CommandExt for Command {
@@ -333,6 +334,18 @@ impl CommandExt for Command {
             bail!("Command failed with status: {}", status);
         }
         Ok(())
+    }
+
+    fn checked_output(&mut self) -> Result<std::process::Output> {
+        let output = self.output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!(
+                "Command {self:?} failed with status: {}. Stderr: {stderr}",
+                output.status,
+            );
+        }
+        Ok(output)
     }
 }
 

--- a/tests/reproduce_status_bugs.rs
+++ b/tests/reproduce_status_bugs.rs
@@ -1,0 +1,53 @@
+#[test]
+#[cfg(unix)]
+fn test_commit_msg_trailer_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ctx = testutil::test_context_minimal!()
+        .install_hooks(true)
+        .build();
+
+    // Manage branch to enable hook
+    ctx.gherrit().args(["manage"]).assert().success();
+
+    let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");
+    std::fs::write(&msg_file, "feat: broken trailers").unwrap();
+
+    // Make file read-only to force 'git interpret-trailers --in-place' to fail
+    let mut perms = std::fs::metadata(&msg_file).unwrap().permissions();
+    perms.set_mode(0o444);
+    std::fs::set_permissions(&msg_file, perms).unwrap();
+
+    // Hook should fail if it can't write trailer
+    ctx.gherrit()
+        .args(["hook", "commit-msg", msg_file.to_str().unwrap()])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_pre_push_edit_failure() {
+    let ctx = testutil::test_context!().build();
+
+    // Setup: Create PR first
+    ctx.checkout_new("feature-edit-fail");
+    ctx.commit("Initial Work");
+    // Initial push creates PR
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+
+    // Amend commit to trigger update (edit)
+    ctx.run_git(&[
+        "commit",
+        "--amend",
+        "--allow-empty",
+        "-m",
+        "Initial Work (Updated)",
+    ]);
+
+    // Run hook with failure injection
+    ctx.gherrit()
+        .args(["hook", "pre-push"])
+        .env("MOCK_BIN_FAIL_CMD", "gh:edit")
+        .assert()
+        .failure();
+}

--- a/tests/reproduce_unchecked_output_bugs.rs
+++ b/tests/reproduce_unchecked_output_bugs.rs
@@ -1,0 +1,85 @@
+#[test]
+fn test_pre_push_ls_remote_failure() {
+    let ctx = testutil::test_context!().build();
+    // Manage branch
+    ctx.checkout_new("feature-ls-remote-fail");
+    ctx.commit("Work");
+
+    // Hook should succeed but warn about ls-remote failure
+    ctx.gherrit()
+        .args(["hook", "pre-push"])
+        .env("MOCK_BIN_FAIL_CMD", "git:ls-remote")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains(
+            "Failed to fetch remote branch states",
+        ));
+}
+
+#[test]
+fn test_pre_push_pr_list_failure() {
+    let ctx = testutil::test_context!().build();
+    ctx.checkout_new("feature-pr-list-fail");
+    ctx.commit("Work");
+
+    // Trigger hook
+    ctx.gherrit()
+        .args(["hook", "pre-push"])
+        .env("MOCK_BIN_FAIL_CMD", "gh:list")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_pre_push_pr_create_failure() {
+    let ctx = testutil::test_context!().build();
+    ctx.checkout_new("feature-pr-create-fail");
+    ctx.commit("Work");
+
+    // Trigger hook
+    ctx.gherrit()
+        .args(["hook", "pre-push"])
+        .env("MOCK_BIN_FAIL_CMD", "gh:create")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_commit_msg_git_var_failure() {
+    #[cfg(unix)]
+    {
+        let ctx = testutil::test_context_minimal!()
+            .install_hooks(true)
+            .build();
+        ctx.gherrit().args(["manage"]).assert().success();
+
+        let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");
+        std::fs::write(&msg_file, "feat: broken git var").unwrap();
+
+        ctx.gherrit()
+            .args(["hook", "commit-msg", msg_file.to_str().unwrap()])
+            .env("MOCK_BIN_FAIL_CMD", "git:var")
+            .assert()
+            .failure();
+    }
+}
+
+#[test]
+fn test_commit_msg_trailers_failure() {
+    #[cfg(unix)]
+    {
+        let ctx = testutil::test_context_minimal!()
+            .install_hooks(true)
+            .build();
+        ctx.gherrit().args(["manage"]).assert().success();
+
+        let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");
+        std::fs::write(&msg_file, "feat: broken trailers parse").unwrap();
+
+        ctx.gherrit()
+            .args(["hook", "commit-msg", msg_file.to_str().unwrap()])
+            .env("MOCK_BIN_FAIL_CMD", "git:interpret-trailers")
+            .assert()
+            .failure();
+    }
+}

--- a/tests/support/mock_bin.rs
+++ b/tests/support/mock_bin.rs
@@ -68,7 +68,19 @@ fn main() {
     }
 }
 
+fn try_simulate_failure(command: &str, args: &[String]) {
+    let Some(subcommand) = args.get(1) else {
+        return;
+    };
+    if env::var("MOCK_BIN_FAIL_CMD").is_ok_and(|t| t == format!("{}:{}", command, subcommand)) {
+        eprintln!("Simulated failure for {} {}", command, subcommand);
+        std::process::exit(1);
+    }
+}
+
 fn handle_git(args: &[String]) {
+    try_simulate_failure("git", args);
+
     // Spy on "push" but pass through to real git
     if args.contains(&"push".to_string()) {
         // Parse refspecs (args that look like refs or have colons)
@@ -104,6 +116,8 @@ fn handle_git(args: &[String]) {
 }
 
 fn handle_gh(args: &[String]) {
+    try_simulate_failure("gh", &args[1..]);
+
     // args[0] is program name, args[1] is subcommand (e.g., "pr")
     let subcmd = args.get(1).map(|s| s.as_str());
     if let Some("pr") = subcmd {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #222


**Latest Update:** v3 — [Compare vs v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v2..gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 |
| :--- | :--- | :--- | :--- |
| v3 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v3) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v1..gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v3) | [vs v2](https://github.com/joshlf/gherrit/compare/gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v2..gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v3) |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v1..gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v2) | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/main..gherrit/Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5/v1) | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "Ge8d72c4d8f9ec03991bdf6f3aeb69a791f9765e5", "parent": null, "child": null} -->