### PR TITLE
[pre-push] Batch PR updates using GraphQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,6 +3430,7 @@ dependencies = [
  "assert_cmd",
  "axum",
  "predicates",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",

--- a/src/util.rs
+++ b/src/util.rs
@@ -374,19 +374,19 @@ pub fn get_github_token() -> Result<String> {
     )
 }
 
+/// Parses the owner and repository name from a remote URL.
+///
+/// Supports the following formats:
+/// - `https://github.com/owner/repo(.git)`
+/// - `git@github.com:owner/repo(.git)`
+/// - `alias:owner/repo(.git)`
 pub fn get_repo_owner_name(remote_url: &str) -> Result<(String, String)> {
     if remote_url.starts_with('/') {
         // Fallback for local tests
         return Ok(("owner".to_string(), "repo".to_string()));
     }
 
-    // Supports:
-    // - https://github.com/owner/repo(.git)
-    // - git@github.com:owner/repo(.git)
-    // - alias:owner/repo(.git)
-    let re = re!(
-        r"^(?:https://github\.com/|[^/:]+:)(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$"
-    );
+    let re = re!(r"^(?:https://github\.com/|[^/:]+:)(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$");
 
     if let Some(caps) = re.captures(remote_url) {
         let owner = caps.name("owner").unwrap().as_str().to_string();

--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = "1.0"
 predicates = "3.1"
 axum = "0.8.7"
 tokio = { version = "1.48.0", features = ["full"] }
+regex = "1.12.2"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #234
- #232
- #229


**Latest Update:** v2 — [Compare vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G7672fe773dd82fdb63e94f333f81581c0e10b1e7/v1..gherrit/G7672fe773dd82fdb63e94f333f81581c0e10b1e7/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 |
| :--- | :--- | :--- |
| v2 | [vs Base](https://github.com/joshlf/gherrit/compare/Ge7329ba459b6ddf662df9a94351ee0318a9f17c9..gherrit/G7672fe773dd82fdb63e94f333f81581c0e10b1e7/v2) | [vs v1](https://github.com/joshlf/gherrit/compare/gherrit/G7672fe773dd82fdb63e94f333f81581c0e10b1e7/v1..gherrit/G7672fe773dd82fdb63e94f333f81581c0e10b1e7/v2) |
| v1 | [vs Base](https://github.com/joshlf/gherrit/compare/Ge7329ba459b6ddf662df9a94351ee0318a9f17c9..gherrit/G7672fe773dd82fdb63e94f333f81581c0e10b1e7/v1) | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G7672fe773dd82fdb63e94f333f81581c0e10b1e7", "parent": "Ge7329ba459b6ddf662df9a94351ee0318a9f17c9", "child": "G618746be40cc6c42e92bb27eb8e136128f6f8794"} -->