### PR TITLE
[test] Add regression test for double-quote bug

### DIFF
--- a/tests/reproduce_double_quote_bug.rs
+++ b/tests/reproduce_double_quote_bug.rs
@@ -1,0 +1,15 @@
+#[test]
+fn test_reproduce_double_quote_bug() {
+    let ctx = testutil::test_context!().build();
+    ctx.checkout_new("feature-double-quote");
+    ctx.commit("Work");
+
+    // The current bug causes the owner/repo to be sent as "\"owner\"" instead of "owner".
+    // The mock server's regex expects `repository(owner: "owner", ...)`
+    // If double quotes are sent, the regex won't match, and the request will fail (or return generic data which causes failure later).
+
+    // In strict mode (which testutil usually provides), un-matched queries might return errors or default responses that key logic depends on.
+
+    // For this test, we expect success. If the bug is present, this should fail because the query won't match the mock expectation for looking up PRs.
+    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #241
- #240


**Latest Update:** v3 — [Compare vs v2](https://github.com/joshlf/gherrit/pull/240/compare/gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v2..gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 |
| :--- | :--- | :--- | :--- |
| v3 | [vs Base](https://github.com/joshlf/gherrit/pull/240/compare/main..gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v3) | [vs v1](https://github.com/joshlf/gherrit/pull/240/compare/gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v1..gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v3) | [vs v2](https://github.com/joshlf/gherrit/pull/240/compare/gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v2..gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v3) |
| v2 | [vs Base](https://github.com/joshlf/gherrit/pull/240/compare/main..gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v2) | [vs v1](https://github.com/joshlf/gherrit/pull/240/compare/gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v1..gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v2) | |
| v1 | [vs Base](https://github.com/joshlf/gherrit/pull/240/compare/main..gherrit/Gee5708dda3a2d117523fcbc6747ccdad234ae14d/v1) | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "Gee5708dda3a2d117523fcbc6747ccdad234ae14d", "parent": null, "child": "G26bdc530aa1c63c6915d19aa3a9d4a2580505824"} -->