### PR TITLE
[pre-push] Invert order of patch comparison table

### DIFF
--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -439,15 +439,17 @@ impl PrBodyBuilder<'_> {
                 )?;
 
                 // Header
-                w.write_str("| Version | Base |")?;
-                for v in 1..slf.latest_version {
-                    write!(w, "v{}|", v)?;
+                w.write_str("|Version|")?;
+                for v in (1..slf.latest_version).rev() {
+                    write!(w, " v{} |", v)?;
                 }
-                w.write_str("\n|:---|:---|")?;
+                w.write_str("Base|")?;
+
+                w.write_str("\n|:---|")?;
                 for _ in 1..slf.latest_version {
                     w.write_str(":---|")?;
                 }
-                w.write_str("\n")?;
+                w.write_str(":---|\n")?;
 
                 let prefix = if slf.latest_version <= 8 { "vs " } else { "" };
 
@@ -455,16 +457,8 @@ impl PrBodyBuilder<'_> {
                 for v_row in (1..=slf.latest_version).rev() {
                     write!(w, "|v{}|", v_row)?;
 
-                    // Base column (v0)
-                    // Compare base_branch..v_row
-                    write!(
-                        w,
-                        "[{}Base]({}/compare/{}..gherrit/{}/v{})|",
-                        prefix, slf.repo_url, slf.base_branch, slf.c.gherrit_id, v_row
-                    )?;
-
                     // Previous version columns
-                    for v_col in 1..slf.latest_version {
+                    for v_col in (1..slf.latest_version).rev() {
                         if v_col < v_row {
                             use HistoryTableFormat::*;
                             // In sparse mode, only show:
@@ -496,6 +490,14 @@ impl PrBodyBuilder<'_> {
                             w.write_str("|")?;
                         }
                     }
+
+                    // Base column (v0) – compare base_branch..v_row.
+                    write!(
+                        w,
+                        "[{}Base]({}/compare/{}..gherrit/{}/v{})|",
+                        prefix, slf.repo_url, slf.base_branch, slf.c.gherrit_id, v_row
+                    )?;
+
                     w.write_str("\n")?;
                 }
                 w.write_str("\n</details>")?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -374,7 +374,7 @@ fn test_pr_body_generation() {
         let body = pr_c.body.as_ref().unwrap();
 
         // Assert table exists now
-        assert!(body.contains("| Version |"), "Patch History Table should appear for v2");
+        assert!(body.contains("|Version|"), "Patch History Table should appear for v2");
         assert!(body.contains("v1|"), "Table should reference v1");
     }
 }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Invert order of columns so that columns are listed in descending order
(just like rows are). Previously, including the left-most column,
columns would "jump" at the beginning – e.g., v10, base, v1, v2, v3.
Now, they descend in a more intuitive manner – v10, v9, v8, ..., base.

Closes #233




---

- #248


**Latest Update:** v5 — [Compare vs v4](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v4..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v4..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v5)|[vs v3](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v3..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v5)|[vs v2](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v2..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v5)|[vs v1](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v1..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v5)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v5)|
|v4||[vs v3](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v3..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v4)|[vs v2](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v2..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v4)|[vs v1](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v1..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v4)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v4)|
|v3|||[vs v2](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v2..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v3)|[vs v1](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v1..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v3)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v3)|
|v2||||[vs v1](/joshlf/gherrit/compare/gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v1..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v2)|
|v1|||||[vs Base](/joshlf/gherrit/compare/main..gherrit/G8057d3f6e661efe47811e17dd6244a8ffa9b32a6/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G8057d3f6e661efe47811e17dd6244a8ffa9b32a6", "parent": null, "child": null}" -->