### PR TITLE
[pre-push] In PR body, indicate current PR

### DIFF
--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -648,17 +648,20 @@ async fn sync_prs(
         })
         .flatten();
 
-    let gh_pr_ids_markdown = commit_pr_states
-        .iter()
-        .rev()
-        .map(|(_, _, pr_state)| format!("- #{}", pr_state.number))
-        .collect::<Vec<_>>()
-        .join("\n");
-
     let updates: Vec<BatchUpdate> = commit_pr_states
         .iter()
         .enumerate()
         .filter_map(|(i, (c, parent_branch, pr_state))| {
+            let gh_pr_ids_markdown = commit_pr_states
+                .iter()
+                .rev()
+                .map(|(_, _, state)| {
+                    let prefix = if state.number == pr_state.number { "👉" } else { "&#x3000;" };
+                    format!("- {} #{}", prefix, state.number)
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
             let latest_version = latest_versions.get(&c.gherrit_id).copied().unwrap_or(1);
 
             let parent_gherrit_id = (i > 0).then(|| commit_pr_states[i - 1].0.gherrit_id.clone());


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Closes #235




---

- &#x3000; #250
- 👉 #249


**Latest Update:** v3 — [Compare vs v2](/joshlf/gherrit/compare/gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v2..gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/joshlf/gherrit/compare/gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v2..gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v3)|[vs v1](/joshlf/gherrit/compare/gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v1..gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v3)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v3)|
|v2||[vs v1](/joshlf/gherrit/compare/gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v1..gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v2)|
|v1|||[vs Base](/joshlf/gherrit/compare/main..gherrit/G1c173d31e24d10cff64f1e25838ad7a5994e45e4/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G1c173d31e24d10cff64f1e25838ad7a5994e45e4", "parent": null, "child": "Ga4950fd85c09700389a54ff4318333cd87518f70"}" -->