### PR TITLE
[pre-push] Remove redundant local `refs/gherrit/` creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@ represented as a chain of Pull Requests on GitHub.
 
 It achieves this by:
 1.  Intercepting `git push` via the `pre-push` hook.
-2.  Creating unique `refs/gherrit/<id>` refs for every commit.
-3.  Pushing these refs to the remote.
-4.  Using the `gh` CLI tool to create/update PRs and chain them together (setting the base of one PR to the head of the previous one).
+2.  Pushing unique `refs/gherrit/<id>` refs for every commit to the remote.
+3.  Using the `gh` CLI tool to create/update PRs and chain them together
+    (setting the base of one PR to the head of the previous one).
 
 ### Project Structure
 

--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -35,7 +35,6 @@ pub async fn run(repo: &util::Repo) -> Result<()> {
     }
 
     let commits = collect_commits(repo).wrap_err("Failed to collect commits")?;
-    let commits = create_gherrit_refs(repo, commits).wrap_err("Failed to create refs")?;
 
     if commits.is_empty() {
         log::info!("No commits to sync.");
@@ -124,17 +123,6 @@ fn collect_commits(repo: &util::Repo) -> Result<Vec<Commit>> {
             c.try_into()
         })
         .collect()
-}
-
-fn create_gherrit_refs(repo: &util::Repo, commits: Vec<Commit>) -> Result<Vec<Commit>> {
-    commits
-        .into_iter()
-        .map(|c| -> Result<_> {
-            let rf = format!("refs/gherrit/{}", c.gherrit_id);
-            let _ = repo.reference(rf, c.id, PreviousValue::Any, "")?;
-            Ok(c)
-        })
-        .collect::<Result<Vec<_>>>()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -222,19 +222,7 @@ fn test_optimistic_locking_conflict() {
     // Push V1
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "optimistic_locking_v1");
 
-    // Retrieve the gherrit_id from local refs
-    let output = ctx
-        .git()
-        .args(["for-each-ref", "--format=%(refname:short)", "refs/gherrit/"])
-        .output()
-        .unwrap();
-    let stdout = std::str::from_utf8(&output.stdout).unwrap();
-    let gherrit_id = stdout
-        .lines()
-        .next()
-        .expect("No gherrit ref found")
-        .strip_prefix("gherrit/")
-        .expect("Invalid ref format");
+    let gherrit_id = ctx.gherrit_id("HEAD").unwrap();
 
     // Simulate race condition: Create v2 tag on REMOTE manually. The next
     // version should be v2 (since v1 exists). Note that in a bare repo, we can

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -381,6 +381,17 @@ impl TestContext {
         cmd
     }
 
+    pub fn gherrit_id(&self, ref_name: &str) -> Result<String, Box<dyn std::error::Error>> {
+        let assert = self.git().args(["log", "-1", "--format=%B", ref_name]).assert().success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+
+        stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("gherrit-pr-id: "))
+            .map(|id| id.trim().to_string())
+            .ok_or_else(|| format!("Commit {} is missing 'gherrit-pr-id' trailer", ref_name).into())
+    }
+
     pub fn sanitize(&self, output: &str) -> String {
         self.sanitize_with_redactions(output, &[])
     }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This change removes the `create_gherrit_refs` step from the pre-push
hook workflow. Previously, this step created local `refs/gherrit/<ID>`
references pointing to the commits in the stack before attempting to
push them.

The core synchronization logic in `push_to_origin` operates directly on
commit objects and does not read these local references. They were
effectively unused by the internal logic and served only as local
"bookmarks" for the user.

Crucially, removing this step eliminates a potential "torn state" bug
regarding local consistency. Previously, `create_gherrit_refs` would
update local references *before* the network push occurred. If the
subsequent `git push` failed (e.g., due to network error or an
optimistic locking failure on the server), the local `refs/gherrit/<ID>`
would be updated to the new commit, but the remote state and local
version tags would effectively still be "old."

By removing these intermediate refs, we ensure that the state is atomic:
either the push succeeds and version tags are persisted, or the push
fails and no local state is modified.

Makes progress on #264




---

- &#x3000; #270
- 👉 #269


**Latest Update:** v3 — [Compare vs v2](/joshlf/gherrit/compare/gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v2..gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/joshlf/gherrit/compare/gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v2..gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v3)|[vs v1](/joshlf/gherrit/compare/gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v1..gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v3)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v3)|
|v2||[vs v1](/joshlf/gherrit/compare/gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v1..gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v2)|
|v1|||[vs Base](/joshlf/gherrit/compare/main..gherrit/Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gd0071e39b5188a2f146a2f9f5899f0e3fdf1da83", "parent": null, "child": "G1598863b2e04dc6b63afa14c06893d7ab19a603f"}" -->