### PR TITLE
Use lower-case base32 for PR IDs

### DIFF
--- a/src/commit_msg.rs
+++ b/src/commit_msg.rs
@@ -109,7 +109,7 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
     // --if-exists doNothing: prevents duplicates
     cmd!(
         "git interpret-trailers --in-place --where start --if-exists doNothing --trailer",
-        "gherrit-pr-id: g{hash_str}",
+        "gherrit-pr-id: G{hash_str}",
         msg_file
     )
     .success()?;

--- a/src/commit_msg.rs
+++ b/src/commit_msg.rs
@@ -93,7 +93,7 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
         hash
     };
 
-    let hash_str = data_encoding::BASE32.encode(&hash);
+    let hash_str = data_encoding::BASE32.encode(&hash).to_ascii_lowercase();
 
     // Check if trailer exists
     let output = cmd!("git interpret-trailers --parse", msg_file).checked_output()?;
@@ -109,7 +109,7 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
     // --if-exists doNothing: prevents duplicates
     cmd!(
         "git interpret-trailers --in-place --where start --if-exists doNothing --trailer",
-        "gherrit-pr-id: G{hash_str}",
+        "gherrit-pr-id: g{hash_str}",
         msg_file
     )
     .success()?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -16,7 +16,7 @@ fn test_commit_msg_hook() {
 
     // Verify trailer was added
     let content = std::fs::read_to_string(msg_file).unwrap();
-    assert!(content.contains("\ngherrit-pr-id: G"));
+    assert!(content.contains("\ngherrit-pr-id: g"));
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -16,7 +16,7 @@ fn test_commit_msg_hook() {
 
     // Verify trailer was added
     let content = std::fs::read_to_string(msg_file).unwrap();
-    assert!(content.contains("\ngherrit-pr-id: g"));
+    assert!(content.contains("\ngherrit-pr-id: G"));
 }
 
 #[test]

--- a/tests/migration_edge_cases.rs
+++ b/tests/migration_edge_cases.rs
@@ -45,14 +45,17 @@ fn test_base32_format_compliance() {
     let id = id_line.trim().strip_prefix("gherrit-pr-id: ").unwrap();
 
     // 1. Case Sensitivity & Normalization
-    // Must be lowercase g + [a-z2-7]
-    assert!(id.starts_with('g'), "ID must start with g");
+    // Must be uppercase G + lowercase [a-z2-7]
+    assert!(id.starts_with('G'), "ID must start with G");
     let content = &id[1..];
     assert!(
         content.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
-        "ID must be lowercase/digits"
+        "ID content must be lowercase/digits"
     );
-    assert!(!content.chars().any(|c| c.is_ascii_uppercase()), "ID must not contain uppercase");
+    assert!(
+        !content.chars().any(|c| c.is_ascii_uppercase()),
+        "ID content must not contain uppercase"
+    );
 
     // 2. Padding & Symbols
     assert!(!content.contains('='), "ID must not contain padding");

--- a/tests/migration_edge_cases.rs
+++ b/tests/migration_edge_cases.rs
@@ -45,14 +45,14 @@ fn test_base32_format_compliance() {
     let id = id_line.trim().strip_prefix("gherrit-pr-id: ").unwrap();
 
     // 1. Case Sensitivity & Normalization
-    // Must be uppercase G + [A-Z2-7]
-    assert!(id.starts_with('G'), "ID must start with G");
+    // Must be lowercase g + [a-z2-7]
+    assert!(id.starts_with('g'), "ID must start with g");
     let content = &id[1..];
     assert!(
-        content.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()),
-        "ID must be uppercase/digits"
+        content.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+        "ID must be lowercase/digits"
     );
-    assert!(!content.chars().any(|c| c.is_ascii_lowercase()), "ID must not contain lowercase");
+    assert!(!content.chars().any(|c| c.is_ascii_uppercase()), "ID must not contain uppercase");
 
     // 2. Padding & Symbols
     assert!(!content.contains('='), "ID must not contain padding");

--- a/tests/migration_edge_cases.rs
+++ b/tests/migration_edge_cases.rs
@@ -49,8 +49,8 @@ fn test_base32_format_compliance() {
     assert!(id.starts_with('G'), "ID must start with G");
     let content = &id[1..];
     assert!(
-        content.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
-        "ID content must be lowercase/digits"
+        content.chars().all(|c| c.is_ascii_lowercase() || matches!(c, '2'..='7')),
+        "ID content must be lowercase letters or digits 2-7"
     );
     assert!(
         !content.chars().any(|c| c.is_ascii_uppercase()),

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -435,7 +435,7 @@ impl TestContext {
             LazyLock::new(|| Regex::new(r"http://127\.0\.0\.1:\d+").expect("Invalid regex"));
 
         static GHERRIT_ID_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"\bG[a-zA-Z0-9]{16,}\b").expect("Invalid regex"));
+            LazyLock::new(|| Regex::new(r"\b[Gg][a-zA-Z0-9]{16,}\b").expect("Invalid regex"));
 
         let output = SHA_REGEX.replace_all(&output, "[SHA]");
         let output = GHERRIT_ID_REGEX.replace_all(&output, "[GHERRIT_ID]");


### PR DESCRIPTION
- Modified `src/commit_msg.rs` to lower-case the base32 hash and use `g` prefix.
- Updated `testutil/src/lib.rs` regex to match `[Gg]` for snapshot redaction.
- Updated `tests/migration_edge_cases.rs` to assert lowercase format.
- Updated `tests/integration_tests.rs` to assert `g` prefix.

---
*PR created automatically by Jules for task [11055275604187936814](https://jules.google.com/task/11055275604187936814) started by @joshlf*