### PR TITLE
Use lower-case base32 for PR IDs

### DIFF
--- a/src/commit_msg.rs
+++ b/src/commit_msg.rs
@@ -93,7 +93,7 @@ pub fn run(repo: &util::Repo, msg_file: &str) -> Result<()> {
         hash
     };
 
-    let hash_str = data_encoding::BASE32.encode(&hash);
+    let hash_str = data_encoding::BASE32.encode(&hash).to_ascii_lowercase();
 
     // Check if trailer exists
     let output = cmd!("git interpret-trailers --parse", msg_file).checked_output()?;

--- a/tests/migration_edge_cases.rs
+++ b/tests/migration_edge_cases.rs
@@ -44,17 +44,13 @@ fn test_base32_format_compliance() {
     let id_line = msg.lines().find(|l| l.starts_with("gherrit-pr-id: ")).expect("ID not found");
     let id = id_line.trim().strip_prefix("gherrit-pr-id: ").unwrap();
 
-    // 1. Case Sensitivity & Normalization
-    // Must be uppercase G + [A-Z2-7]
+    // Must be uppercase G + [a-z2-7]
     assert!(id.starts_with('G'), "ID must start with G");
     let content = &id[1..];
     assert!(
-        content.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()),
-        "ID must be uppercase/digits"
+        content.chars().all(|c| matches!(c, 'a'..='z' | '2'..='7')),
+        "ID content must be lowercase letters or digits 2-7"
     );
-    assert!(!content.chars().any(|c| c.is_ascii_lowercase()), "ID must not contain lowercase");
 
-    // 2. Padding & Symbols
-    assert!(!content.contains('='), "ID must not contain padding");
     assert_eq!(id.len(), 33, "ID length should be 33 (1 prefix + 32 hash)");
 }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Makes progress on #287




---

- 👉 #292


**Latest Update:** v3 — [Compare vs v2](/joshlf/gherrit/compare/gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v2..gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/joshlf/gherrit/compare/gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v2..gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v3)|[vs v1](/joshlf/gherrit/compare/gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v1..gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v3)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v3)|
|v2||[vs v1](/joshlf/gherrit/compare/gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v1..gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v2)|
|v1|||[vs Base](/joshlf/gherrit/compare/main..gherrit/G5scphwsfjzp74evnhrrrvr4o5txpwut6/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G5scphwsfjzp74evnhrrrvr4o5txpwut6 && git checkout -b pr-G5scphwsfjzp74evnhrrrvr4o5txpwut6 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G5scphwsfjzp74evnhrrrvr4o5txpwut6 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G5scphwsfjzp74evnhrrrvr4o5txpwut6 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G5scphwsfjzp74evnhrrrvr4o5txpwut6
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G5scphwsfjzp74evnhrrrvr4o5txpwut6", "parent": null, "child": null}" -->