### PR TITLE
[hooks][pre-push] Accept remote arguments

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-gherrit hook pre-push
+gherrit hook pre-push "$@"
 exit $?

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,14 @@ enum Commands {
 #[derive(Subcommand)]
 enum HookCommands {
     /// Git pre-push hook.
-    PrePush,
+    PrePush {
+        /// Name of the remote being pushed to.
+        #[arg(requires = "remote_location")]
+        remote_name: Option<String>,
+        /// Location of the remote being pushed to.
+        #[arg(requires = "remote_name")]
+        remote_location: Option<String>,
+    },
     /// Git post-checkout hook.
     PostCheckout { prev: String, new: String, flag: String },
     /// Git commit-msg hook.
@@ -115,7 +122,7 @@ fn run() -> Result<()> {
 
     match cli.command {
         Commands::Hook(cmd) => match cmd {
-            HookCommands::PrePush => {
+            HookCommands::PrePush { .. } => {
                 tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()?

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -399,6 +399,14 @@ fn test_install_command_edge_cases() {
 }
 
 #[test]
+fn test_installed_pre_push_hook_accepts_git_arguments() {
+    let ctx = testutil::test_context_minimal!().install_hooks(true).initial_commit(true).build();
+
+    // Git invokes the pre-push hook with the remote name and location.
+    ctx.git().args(["push", "origin", "main"]).assert().success();
+}
+
+#[test]
 fn test_install_configuration_and_security() {
     let ctx = testutil::test_context_minimal!().build();
 


### PR DESCRIPTION
Git invokes pre-push hooks with the remote name and location. The hook installer forwards these arguments, but the pre-push subcommand rejected them, causing pushes through an installed hook to fail.

Accept either both arguments or neither, and cover the installed-hook path with an integration test.

gherrit-pr-id: Ggx6ijywebydig7qjeqiynjfrdzxq5jzg