### PR TITLE
[tests] Match GraphQL failures by operation

### DIFF
--- a/tests/reproduce_status_bugs.rs
+++ b/tests/reproduce_status_bugs.rs
@@ -34,7 +34,7 @@ fn test_pre_push_edit_failure() {
     ctx.run_git(&["commit", "--amend", "--allow-empty", "-m", "Initial Work (Updated)"]);
 
     // Run hook with failure injection
-    ctx.inject_failure(testutil::FailureKind::UpdatePr, 5);
+    ctx.inject_failure(testutil::FailureKind::UpdatePr);
 
     ctx.gherrit().args(["hook", "pre-push"]).assert().failure();
 }

--- a/tests/reproduce_unchecked_output_bugs.rs
+++ b/tests/reproduce_unchecked_output_bugs.rs
@@ -23,7 +23,7 @@ fn test_pre_push_pr_list_failure() {
     ctx.commit("Work");
 
     // Trigger hook
-    ctx.inject_failure(testutil::FailureKind::GraphQl, 5);
+    ctx.inject_failure(testutil::FailureKind::GraphQl);
 
     ctx.gherrit().args(["hook", "pre-push"]).assert().failure();
 }
@@ -35,7 +35,7 @@ fn test_pre_push_pr_create_failure() {
     ctx.commit("Work");
 
     // Trigger hook
-    ctx.inject_failure(testutil::FailureKind::CreatePr, 5);
+    ctx.inject_failure(testutil::FailureKind::CreatePr);
 
     ctx.gherrit().args(["hook", "pre-push"]).assert().failure();
 }

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -303,12 +303,11 @@ impl TestContext {
         self.run_git(&["checkout", "-b", branch_name]);
     }
 
-    pub fn inject_failure(&self, kind: FailureKind, remaining: usize) {
+    pub fn inject_failure(&self, kind: FailureKind) {
         let mut state =
             self.mock_server_state.as_ref().expect("Mock state not available").write().unwrap();
 
         state.fail_next_request = Some(kind);
-        state.fail_remaining = remaining;
     }
 
     pub fn maybe_inspect_mock_state(&self, f: impl FnOnce(&mock_server::MockState)) {

--- a/testutil/src/mock_server.rs
+++ b/testutil/src/mock_server.rs
@@ -21,12 +21,19 @@ pub struct MockState {
     pub prs: Vec<PrEntry>,
     pub pushed_refs: Vec<String>,
     pub push_count: usize,
+    pub graphql_requests: Vec<Vec<GraphQlOperation>>,
     pub repo_owner: String,
     pub repo_name: String,
     pub fail_next_request: Option<FailureKind>,
-    pub fail_remaining: usize,
     pub merge_queue: HashSet<u64>,
     pub schema: Option<Valid<apollo_compiler::Schema>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphQlOperation {
+    Query,
+    CreatePr,
+    UpdatePr,
 }
 
 impl MockState {
@@ -211,14 +218,47 @@ fn check_and_apply_failure(mock_state: &mut MockState, action: FailureKind) -> b
         return false;
     }
 
-    if mock_state.fail_remaining > 0 {
-        mock_state.fail_remaining -= 1;
-    }
-    if mock_state.fail_remaining == 0 {
-        mock_state.fail_next_request = None;
-    }
+    mock_state.fail_next_request = None;
 
     true
+}
+
+fn check_and_apply_graphql_failure(
+    mock_state: &mut MockState,
+    operations: &[GraphQlOperation],
+) -> Option<FailureKind> {
+    use FailureKind::*;
+
+    let fail_action = mock_state.fail_next_request.as_ref()?;
+    let matches = match fail_action {
+        GraphQl => true,
+        CreatePr => operations.contains(&GraphQlOperation::CreatePr),
+        UpdatePr => operations.contains(&GraphQlOperation::UpdatePr),
+        Named(_) => false,
+    };
+
+    if !matches {
+        return None;
+    }
+
+    mock_state.fail_next_request.take()
+}
+
+fn graphql_operations(document: &ExecutableDocument) -> Vec<GraphQlOperation> {
+    document
+        .operations
+        .iter()
+        .flat_map(|operation| operation.selection_set.selections.iter())
+        .filter_map(|selection| {
+            let executable::Selection::Field(field) = selection else { return None };
+            match field.name.as_str() {
+                "repository" => Some(GraphQlOperation::Query),
+                "createPullRequest" => Some(GraphQlOperation::CreatePr),
+                "updatePullRequest" => Some(GraphQlOperation::UpdatePr),
+                _ => None,
+            }
+        })
+        .collect()
 }
 
 async fn handle_git(
@@ -335,17 +375,6 @@ async fn graphql(
 
     let mut mock_state = state.state.write().unwrap();
 
-    if check_and_apply_failure(&mut mock_state, FailureKind::UpdatePr)
-        || check_and_apply_failure(&mut mock_state, FailureKind::CreatePr)
-        || check_and_apply_failure(&mut mock_state, FailureKind::GraphQl)
-    {
-        return Ok(Json(serde_json::json!({
-            "errors": [
-                { "message": "Injected failure" }
-            ]
-        })));
-    }
-
     let schema = mock_state.schema.as_ref().expect("Schema not initialized");
     let document = match ExecutableDocument::parse_and_validate(schema, query, "query.graphql") {
         Ok(doc) => doc,
@@ -354,6 +383,16 @@ async fn graphql(
             return Err(StatusCode::BAD_REQUEST);
         }
     };
+
+    let operations = graphql_operations(&document);
+    mock_state.graphql_requests.push(operations.clone());
+    if let Some(failure) = check_and_apply_graphql_failure(&mut mock_state, &operations) {
+        return Ok(Json(serde_json::json!({
+            "errors": [
+                { "message": format!("Injected {failure:?} failure") }
+            ]
+        })));
+    }
 
     let mut response_data = serde_json::Map::new();
 
@@ -402,6 +441,43 @@ async fn graphql(
     }
 
     Ok(Json(serde_json::Value::Object(response_json)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_failure_only_matches_the_requested_operation() {
+        let mut state =
+            MockState { fail_next_request: Some(FailureKind::UpdatePr), ..Default::default() };
+
+        assert_eq!(check_and_apply_graphql_failure(&mut state, &[GraphQlOperation::Query]), None);
+        assert_eq!(state.fail_next_request, Some(FailureKind::UpdatePr));
+
+        assert_eq!(
+            check_and_apply_graphql_failure(&mut state, &[GraphQlOperation::CreatePr]),
+            None
+        );
+
+        assert_eq!(
+            check_and_apply_graphql_failure(&mut state, &[GraphQlOperation::UpdatePr]),
+            Some(FailureKind::UpdatePr)
+        );
+        assert_eq!(state.fail_next_request, None);
+    }
+
+    #[test]
+    fn generic_graphql_failure_matches_any_operation() {
+        let mut state =
+            MockState { fail_next_request: Some(FailureKind::GraphQl), ..Default::default() };
+
+        assert_eq!(
+            check_and_apply_graphql_failure(&mut state, &[GraphQlOperation::Query]),
+            Some(FailureKind::GraphQl)
+        );
+        assert_eq!(state.fail_next_request, None);
+    }
 }
 
 fn extract_input_field<'a>(


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Operation-specific failures were applied before the mock parsed the
request, so create and update failures were consumed by preceding
queries.

Parse and classify each request first, record its operations, and
consume one-shot failures only when their intended operation is
reached.




---

- 　  #308
- 　  #307
- 　  #306
- 　  #305
- 　  #303
- 　  #302
- 　  #301
- 　  #300
- 　  #299
- 　  #298
- 　  #297
- 👉 #296


**Latest Update:** v5 — [Compare vs v4](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v4..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v4..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v5)|[vs v3](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v3..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v5)|[vs v2](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v2..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v5)|[vs v1](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v1..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v5)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v5)|
|v4||[vs v3](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v3..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v4)|[vs v2](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v2..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v4)|[vs v1](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v1..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v4)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v4)|
|v3|||[vs v2](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v2..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v3)|[vs v1](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v1..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v3)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v3)|
|v2||||[vs v1](/joshlf/gherrit/compare/gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v1..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v2)|
|v1|||||[vs Base](/joshlf/gherrit/compare/main..gherrit/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm && git checkout -b pr-Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gdnafuhd5qqmjmnkbvbnznx5isjvpqfnm", "parent": null, "child": "Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu"}" -->