### PR TITLE
[tests] Record completed Git pushes

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -43,8 +43,9 @@ fn test_full_stack_lifecycle_mocked() {
     testutil::assert_pr_snapshot!(ctx, "full_stack_lifecycle_state");
 
     ctx.maybe_inspect_mock_state(|state| {
-        assert!(!state.pushed_refs.is_empty(), "Expected some refs to be pushed");
+        assert!(state.pushes.iter().any(|push| push.succeeded()), "Expected a successful push");
     });
+    assert!(!ctx.remote_refs("refs/heads").is_empty(), "Expected remote branches to be updated");
 }
 
 #[test]
@@ -183,7 +184,7 @@ fn test_version_increment() {
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "version_increment_v1");
 
     // Verify v1 pushed
-    let v1_count = ctx.count_pushed_containing("/v1");
+    let v1_count = ctx.count_successfully_pushed_containing("/v1");
     assert!(v1_count > 0, "Expected v1 tag to be pushed");
 
     // Amend commit (modifies SHA, keeps Change-ID)
@@ -193,19 +194,18 @@ fn test_version_increment() {
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "version_increment_v2");
 
     // Verify v2 pushed
-    let v2_count = ctx.count_pushed_containing("/v2");
+    let v2_count = ctx.count_successfully_pushed_containing("/v2");
     assert!(v2_count > 0, "Expected v2 tag to be pushed");
 
     // Verify v1 NOT pushed AGAIN.
-    let v1_count_final = ctx.count_pushed_containing("/v1");
+    let v1_count_final = ctx.count_successfully_pushed_containing("/v1");
     assert_eq!(v1_count_final, v1_count, "v1 tag should NOT be pushed again in the second push.");
 
     if !ctx.is_live {
         // Verify that tags actually exist on the remote
-        let output = ctx.remote_git().args(["tag", "-l"]).output().unwrap();
-        let tags = std::str::from_utf8(&output.stdout).unwrap();
-        assert!(tags.contains("/v1"), "Remote should contain v1 tag");
-        assert!(tags.contains("/v2"), "Remote should contain v2 tag");
+        let tags = ctx.remote_refs("refs/tags/gherrit");
+        assert!(tags.iter().any(|tag| tag.ends_with("/v1")), "Remote should contain v1 tag");
+        assert!(tags.iter().any(|tag| tag.ends_with("/v2")), "Remote should contain v2 tag");
     }
 }
 
@@ -221,6 +221,8 @@ fn test_optimistic_locking_conflict() {
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "optimistic_locking_v1");
 
     let gherrit_id = ctx.gherrit_id("HEAD").unwrap();
+    let managed_ref = format!("refs/heads/{gherrit_id}");
+    let pushed_oid = ctx.remote_ref_oid(&managed_ref).expect("Managed ref was not pushed");
 
     // Simulate race condition: Create v2 tag on REMOTE manually. The next
     // version should be v2 (since v1 exists). Note that in a bare repo, we can
@@ -242,6 +244,17 @@ fn test_optimistic_locking_conflict() {
 
     // Attempt push - should fail due to atomic lock
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "optimistic_locking_v2_fail");
+
+    ctx.maybe_inspect_mock_state(|state| {
+        assert_eq!(state.pushes.len(), 2, "Expected one successful and one failed push");
+        assert!(state.pushes[0].succeeded(), "Initial push should succeed");
+        assert!(!state.pushes[1].succeeded(), "Conflicting push should fail");
+    });
+    assert_eq!(
+        ctx.remote_ref_oid(&managed_ref).as_deref(),
+        Some(pushed_oid.as_str()),
+        "Failed atomic push must not update the managed ref"
+    );
 }
 
 #[test]
@@ -295,16 +308,20 @@ fn test_large_stack_batching() {
     ctx.maybe_inspect_mock_state(|state| {
         // Assert: Push was split into 2 batches (80 + 5)
         assert_eq!(
-            state.push_count, 2,
+            state.pushes.iter().filter(|push| push.succeeded()).count(),
+            2,
             "Expected 2 push invocations for 85 commits (batch size 80)"
         );
     });
 
     testutil::assert_pr_snapshot!(ctx, "large_stack_batching_state");
 
-    // Assert: 85 refs pushed (actually more, since tags are also pushed)
-    // Check refs/gherrit/<ID>/v1 count.
-    let v1_refs = ctx.count_pushed_containing("/v1");
+    // Verify that every version tag exists on the authoritative remote.
+    let v1_refs = ctx
+        .remote_refs("refs/tags/gherrit")
+        .into_iter()
+        .filter(|ref_name| ref_name.ends_with("/v1"))
+        .count();
     assert_eq!(v1_refs, 85, "Expected 85 v1 specific refs pushed");
 }
 

--- a/tests/migration_edge_cases.rs
+++ b/tests/migration_edge_cases.rs
@@ -19,14 +19,8 @@ fn test_mixed_stack_backward_compatibility() {
     // but here we mainly care that it doesn't crash and processes both.
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "mixed_stack_backward_compatibility");
 
-    // Verify mock state has 2 pushed refs
-    ctx.maybe_inspect_mock_state(|state| {
-        // We expect push of legacy ID and new ID
-        // Note: The legacy ID commit might not look like a "new" PR if the mock logic splits it,
-        // but let's just check that we pushed *something* related to the legacy ID.
-        let pushed_legacy = state.pushed_refs.iter().any(|r| r.contains(legacy_id));
-        assert!(pushed_legacy, "Expected legacy ID to be pushed");
-    });
+    let legacy_ref = format!("refs/heads/{legacy_id}");
+    assert!(ctx.remote_ref_oid(&legacy_ref).is_some(), "Expected legacy ID to be pushed");
 }
 
 #[test]

--- a/tests/prevent_push_to_closed_pr.rs
+++ b/tests/prevent_push_to_closed_pr.rs
@@ -7,6 +7,7 @@ fn verify_push_to_non_open_fail(state_arg: &str, expected_msg_part: &str) {
     // 1. Initial Push (Creates PR)
     ctx.commit("Initial Work");
     ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    let refs_before_rejected_push = ctx.remote_refs("refs");
 
     // 2. Simulate PR State Change on GitHub
     ctx.maybe_mutate_mock_state(|state| {
@@ -23,8 +24,13 @@ fn verify_push_to_non_open_fail(state_arg: &str, expected_msg_part: &str) {
     testutil::assert_pr_snapshot!(ctx, name.as_str());
 
     ctx.maybe_inspect_mock_state(|state| {
-        assert_eq!(state.push_count, 1, "Should not have pushed to {state_arg} PR");
+        assert_eq!(
+            state.pushes.iter().filter(|push| push.succeeded()).count(),
+            1,
+            "Should not have pushed to {state_arg} PR"
+        );
     });
+    assert_eq!(ctx.remote_refs("refs"), refs_before_rejected_push);
 }
 
 #[test]

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -269,7 +269,7 @@ impl TestContext {
     }
 
     pub fn remote_git(&self) -> assert_cmd::Command {
-        let mut cmd = assert_cmd::Command::new("git");
+        let mut cmd = assert_cmd::Command::new(&self.system_git);
         cmd.current_dir(&self.remote_path);
         self.configure_mock_env(&mut cmd);
         cmd
@@ -334,25 +334,41 @@ impl TestContext {
         content
     }
 
-    pub fn assert_pushed(&self, ref_name: &str) {
-        self.maybe_inspect_mock_state(|state| {
-            let found = state.pushed_refs.iter().any(|r| r == ref_name);
-            assert!(
-                found,
-                "Expected ref '{}' to be pushed. Refs: {:?}",
-                ref_name, state.pushed_refs
-            );
-        });
+    pub fn remote_ref_oid(&self, ref_name: &str) -> Option<String> {
+        let output = self
+            .remote_git()
+            .args(["rev-parse", "--verify", "--quiet", ref_name])
+            .output()
+            .expect("Failed to inspect remote ref");
+        match output.status.code() {
+            Some(0) => Some(String::from_utf8(output.stdout).unwrap().trim().to_string()),
+            Some(1) => None,
+            code => panic!("git rev-parse failed with exit code {code:?}"),
+        }
     }
 
-    pub fn count_pushed_containing(&self, substring: &str) -> usize {
+    pub fn remote_refs(&self, prefix: &str) -> Vec<String> {
+        let assert = self
+            .remote_git()
+            .args(["for-each-ref", "--format=%(refname)", prefix])
+            .assert()
+            .success();
+        String::from_utf8(assert.get_output().stdout.clone())
+            .unwrap()
+            .lines()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    pub fn count_successfully_pushed_containing(&self, substring: &str) -> usize {
         let mut count = 0;
         self.maybe_inspect_mock_state(|state| {
             count = state
-                .pushed_refs
+                .pushes
                 .iter()
-                .filter(|r| !r.starts_with("--"))
-                .filter(|r| r.contains(substring))
+                .filter(|push| push.succeeded())
+                .flat_map(|push| &push.refspecs)
+                .filter(|refspec| refspec.contains(substring))
                 .count();
         });
         count
@@ -426,6 +442,7 @@ impl TestContext {
         for (target, replacement) in redactions {
             output = output.replace(target, replacement);
         }
+        let output = normalize_git_diagnostic_separators(&output);
 
         static SHA_REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"\b[0-9a-f]{40}\b").expect("Invalid regex"));
@@ -440,6 +457,15 @@ impl TestContext {
         let output = GHERRIT_ID_REGEX.replace_all(&output, "[GHERRIT_ID]");
         MOCK_URL_REGEX.replace_all(&output, "[MOCK_SERVER_URL]").to_string()
     }
+}
+
+fn normalize_git_diagnostic_separators(output: &str) -> String {
+    static ATOMIC_PUSH_SEPARATOR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?m)^(error: atomic push failed[^\r\n]*\r?\n)(?:\r?\n)+(To )")
+            .expect("Invalid regex")
+    });
+
+    ATOMIC_PUSH_SEPARATOR_REGEX.replace_all(output, "${1}${2}").into_owned()
 }
 
 pub trait IntoCommandRef {
@@ -546,3 +572,30 @@ static SYSTEM_GIT: LazyLock<PathBuf> = LazyLock::new(|| -> PathBuf {
     let path = stdout.lines().next().expect("No git path found").trim();
     PathBuf::from(path)
 });
+
+#[cfg(test)]
+mod git_diagnostic_tests {
+    use super::normalize_git_diagnostic_separators;
+
+    #[test]
+    fn normalizes_only_atomic_push_separator_lines() {
+        let canonical = concat!(
+            "before\n",
+            "error: atomic push failed for ref refs/tags/v2. status: 7\n",
+            "To remote\n",
+            "after\n",
+        );
+        let with_separator = concat!(
+            "before\n",
+            "error: atomic push failed for ref refs/tags/v2. status: 7\n",
+            "\n",
+            "To remote\n",
+            "after\n",
+        );
+        assert_eq!(normalize_git_diagnostic_separators(canonical), canonical);
+        assert_eq!(normalize_git_diagnostic_separators(with_separator), canonical);
+
+        let unrelated = "error: another failure\n\nTo remote\n";
+        assert_eq!(normalize_git_diagnostic_separators(unrelated), unrelated);
+    }
+}

--- a/testutil/src/mock_bin.rs
+++ b/testutil/src/mock_bin.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, env, path::PathBuf, process::Command};
 
-use testutil::mock_server::{GitRequest, GitResponse};
+use testutil::mock_server::{GitCompletion, GitRequest, GitResponse};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -32,14 +32,18 @@ fn handle_git(args: &[String]) {
         eprint!("{}", resp.stderr);
     }
 
-    if resp.passthrough {
-        run_real_git(args);
-    } else {
+    if !resp.passthrough {
         std::process::exit(resp.exit_code);
     }
+
+    let exit_code = run_real_git(args);
+    if resp.report_exit_status {
+        report_exit_status(&server_url, args, exit_code);
+    }
+    std::process::exit(exit_code);
 }
 
-fn run_real_git(args: &[String]) {
+fn run_real_git(args: &[String]) -> i32 {
     // Pass through to real `git` command
     let real_git = env::var("SYSTEM_GIT_PATH").unwrap_or_else(|_| "git".to_string());
 
@@ -48,5 +52,12 @@ fn run_real_git(args: &[String]) {
         .status()
         .expect("Failed to run real git from mock shim");
 
-    std::process::exit(status.code().unwrap_or(1));
+    status.code().unwrap_or(1)
+}
+
+fn report_exit_status(server_url: &str, args: &[String], exit_code: i32) {
+    let completion = GitCompletion { args: args.to_vec(), exit_code };
+    ureq::post(&format!("{}/_internal/git/complete", server_url))
+        .send_json(completion)
+        .expect("Failed to report real git exit status to mock server");
 }

--- a/testutil/src/mock_server.rs
+++ b/testutil/src/mock_server.rs
@@ -19,8 +19,7 @@ use crate::FailureKind;
 #[derive(Debug, Clone, Default)]
 pub struct MockState {
     pub prs: Vec<PrEntry>,
-    pub pushed_refs: Vec<String>,
-    pub push_count: usize,
+    pub pushes: Vec<GitPush>,
     pub graphql_requests: Vec<Vec<GraphQlOperation>>,
     pub repo_owner: String,
     pub repo_name: String,
@@ -175,6 +174,26 @@ pub struct GitResponse {
     pub stderr: String,
     pub exit_code: i32,
     pub passthrough: bool,
+    pub report_exit_status: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GitCompletion {
+    pub args: Vec<String>,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitPush {
+    pub args: Vec<String>,
+    pub refspecs: Vec<String>,
+    pub exit_code: i32,
+}
+
+impl GitPush {
+    pub fn succeeded(&self) -> bool {
+        self.exit_code == 0
+    }
 }
 
 #[derive(Clone)]
@@ -196,6 +215,7 @@ pub async fn start_mock_server(state: Arc<RwLock<MockState>>) -> String {
         .route("/repos/{owner}/{repo}/pulls", get(list_prs))
         .route("/graphql", post(graphql))
         .route("/_internal/git", post(handle_git))
+        .route("/_internal/git/complete", post(complete_git))
         .with_state(app_state);
 
     tokio::spawn(async move {
@@ -261,39 +281,106 @@ fn graphql_operations(document: &ExecutableDocument) -> Vec<GraphQlOperation> {
         .collect()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GitCommand<'a> {
+    name: &'a str,
+    args: &'a [String],
+}
+
+/// Parses the command portion of a Git invocation.
+///
+/// Git accepts global options between the executable and subcommand. Keep this
+/// list in sync with the public options documented by `git(1)`, and fail
+/// closed for unknown or incomplete options rather than mistaking one of their
+/// arguments for a subcommand.
+fn parse_git_command(args: &[String]) -> Option<GitCommand<'_>> {
+    let mut remaining = args.get(1..)?;
+
+    loop {
+        let (arg, rest) = remaining.split_first()?;
+        match arg.as_str() {
+            // These options consume the following argument.
+            "-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace" | "--config-env"
+            | "--attr-source" => {
+                remaining = rest.get(1..)?;
+            }
+
+            // These options affect how Git dispatches the eventual command.
+            "-p"
+            | "--paginate"
+            | "-P"
+            | "--no-pager"
+            | "--bare"
+            | "--no-replace-objects"
+            | "--no-lazy-fetch"
+            | "--no-optional-locks"
+            | "--no-advice"
+            | "--literal-pathspecs"
+            | "--glob-pathspecs"
+            | "--noglob-pathspecs"
+            | "--icase-pathspecs" => {
+                remaining = rest;
+            }
+
+            // These forms carry their value in the same argument.
+            _ if [
+                "--exec-path=",
+                "--git-dir=",
+                "--work-tree=",
+                "--namespace=",
+                "--config-env=",
+                "--attr-source=",
+            ]
+            .iter()
+            .any(|prefix| arg.starts_with(prefix)) =>
+            {
+                remaining = rest;
+            }
+
+            // These are complete Git requests, not options preceding a
+            // subcommand. Any following argument is data for the request.
+            "-v" | "--version" | "-h" | "--help" | "--exec-path" | "--html-path" | "--man-path"
+            | "--info-path" => return None,
+            _ if arg.starts_with("--list-cmds=") => return None,
+
+            // Git does not support `--` before its subcommand. Unknown global
+            // options are likewise not safe to parse through.
+            _ if arg.starts_with('-') => return None,
+            name => return Some(GitCommand { name, args: rest }),
+        }
+    }
+}
+
 async fn handle_git(
     State(app_state): State<AppState>,
     Json(req): Json<GitRequest>,
 ) -> Json<GitResponse> {
+    let command = parse_git_command(&req.args);
+    let is_push = command.is_some_and(|command| command.name == "push");
+
     // Check for simulated failure
-    if let Some(subcommand) = req.args.get(1) {
+    if let Some(command) = command {
         if req
             .env
             .get("MOCK_BIN_FAIL_CMD")
-            .is_some_and(|fail_cmd| fail_cmd == &format!("git:{}", subcommand))
+            .is_some_and(|fail_cmd| fail_cmd == &format!("git:{}", command.name))
         {
+            if is_push {
+                record_push(&app_state, req.args.clone(), 1);
+            }
             return Json(GitResponse {
                 stdout: "".to_string(),
-                stderr: format!("Simulated failure for git {}", subcommand),
+                stderr: format!("Simulated failure for git {}", command.name),
                 exit_code: 1,
                 passthrough: false,
+                report_exit_status: false,
             });
         }
     }
 
     // Spy on "push" logic
-    if req.args.contains(&"push".to_string()) {
-        let mut state = app_state.state.write().unwrap();
-        let refspecs: Vec<String> = req
-            .args
-            .iter()
-            .skip(1)
-            .filter(|arg| arg.starts_with("refs/") || arg.contains(":"))
-            .cloned()
-            .collect();
-
-        state.pushed_refs.extend(refspecs);
-        state.push_count += 1;
+    if is_push {
+        let state = app_state.state.read().unwrap();
         let repo_owner = state.repo_owner.clone();
         let repo_name = state.repo_name.clone();
 
@@ -309,6 +396,7 @@ async fn handle_git(
             stderr,
             exit_code: 0,
             passthrough: true,
+            report_exit_status: true,
         });
     }
 
@@ -318,7 +406,154 @@ async fn handle_git(
         stderr: "".to_string(),
         exit_code: 0,
         passthrough: true,
+        report_exit_status: false,
     })
+}
+
+async fn complete_git(
+    State(app_state): State<AppState>,
+    Json(completion): Json<GitCompletion>,
+) -> StatusCode {
+    if parse_git_command(&completion.args).is_none_or(|command| command.name != "push") {
+        return StatusCode::BAD_REQUEST;
+    }
+
+    record_push(&app_state, completion.args, completion.exit_code);
+    StatusCode::NO_CONTENT
+}
+
+fn record_push(app_state: &AppState, args: Vec<String>, exit_code: i32) {
+    let command = parse_git_command(&args)
+        .filter(|command| command.name == "push")
+        .expect("record_push requires a parsed Git push");
+    let refspecs = command
+        .args
+        .iter()
+        .filter(|arg| !arg.starts_with('-'))
+        .filter(|arg| {
+            let refspec = arg.trim_start_matches('+');
+            refspec.starts_with("refs/")
+                || refspec
+                    .split_once(':')
+                    .is_some_and(|(_, destination)| destination.starts_with("refs/"))
+        })
+        .cloned()
+        .collect();
+    app_state.state.write().unwrap().pushes.push(GitPush { args, refspecs, exit_code });
+}
+
+#[cfg(test)]
+mod git_tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    fn app_state() -> AppState {
+        AppState {
+            state: Arc::new(RwLock::new(MockState::new("owner".to_string(), "repo".to_string()))),
+            base_url: "http://example.test".to_string(),
+        }
+    }
+
+    #[test]
+    fn parses_subcommand_after_documented_git_global_options() {
+        let invocation = args(&[
+            "git",
+            "-C",
+            "repo",
+            "-c",
+            "color.ui=false",
+            "--git-dir=.git",
+            "--work-tree",
+            ".",
+            "--namespace=tests",
+            "--config-env",
+            "user.name=TEST_USER",
+            "--exec-path=/git-core",
+            "--no-pager",
+            "--literal-pathspecs",
+            "--attr-source=HEAD",
+            "push",
+            "origin",
+            "HEAD:refs/heads/main",
+        ]);
+
+        let command = parse_git_command(&invocation).unwrap();
+        assert_eq!(command.name, "push");
+        assert_eq!(command.args, args(&["origin", "HEAD:refs/heads/main"]));
+    }
+
+    #[test]
+    fn does_not_find_push_outside_the_subcommand_position() {
+        for invocation in [
+            args(&["git", "show", "push"]),
+            args(&["git", "--help", "push"]),
+            args(&["git", "--list-cmds=main", "push"]),
+            args(&["git", "--unknown", "push"]),
+            args(&["git", "-c", "push"]),
+        ] {
+            assert_ne!(parse_git_command(&invocation).map(|command| command.name), Some("push"));
+        }
+    }
+
+    #[tokio::test]
+    async fn records_completed_push_after_git_global_options() {
+        let app_state = app_state();
+        let invocation = args(&[
+            "git",
+            "-c",
+            "remote.origin.push=refs/fake:refs/heads/fake",
+            "push",
+            "origin",
+            "+HEAD:refs/heads/main",
+        ]);
+        let request =
+            GitRequest { args: invocation.clone(), cwd: "/repo".to_string(), env: HashMap::new() };
+
+        let Json(response) = handle_git(State(app_state.clone()), Json(request)).await;
+        assert!(response.passthrough);
+        assert!(response.report_exit_status);
+        assert!(app_state.state.read().unwrap().pushes.is_empty());
+
+        let status = complete_git(
+            State(app_state.clone()),
+            Json(GitCompletion { args: invocation.clone(), exit_code: 0 }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let state = app_state.state.read().unwrap();
+        assert_eq!(
+            state.pushes,
+            [GitPush {
+                args: invocation,
+                refspecs: vec!["+HEAD:refs/heads/main".to_string()],
+                exit_code: 0,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn failure_injection_uses_parsed_git_subcommand() {
+        let app_state = app_state();
+        let invocation = args(&["git", "-c", "color.ui=false", "push", "origin", "main"]);
+        let request = GitRequest {
+            args: invocation.clone(),
+            cwd: "/repo".to_string(),
+            env: HashMap::from([("MOCK_BIN_FAIL_CMD".to_string(), "git:push".to_string())]),
+        };
+
+        let Json(response) = handle_git(State(app_state.clone()), Json(request)).await;
+        assert!(!response.passthrough);
+        assert!(!response.report_exit_status);
+        assert_eq!(response.exit_code, 1);
+        assert_eq!(
+            app_state.state.read().unwrap().pushes,
+            [GitPush { args: invocation, refspecs: Vec::new(), exit_code: 1 }]
+        );
+    }
 }
 
 async fn list_prs(


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The mock recorded pushes before real Git ran, so rejected atomic
pushes appeared successful in test state.

Have the Git shim report real Git’s exit status and distinguish
successful and failed attempts. Use the bare remote as the authority
for ref state.

Parse documented Git global options before classifying the subcommand,
and use the result consistently for failure injection, completion
validation, and refspec extraction.

Canonicalize an optional, version-dependent separator in snapshots of
Git’s atomic-push diagnostics so full output remains portable.




---

- 　  #308
- 　  #307
- 　  #306
- 　  #305
- 　  #303
- 　  #302
- 　  #301
- 　  #300
- 　  #299
- 　  #298
- 👉 #297


**Latest Update:** v6 — [Compare vs v5](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v5..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|
|v6|[vs v5](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v5..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v6)|[vs v4](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v4..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v6)|[vs v3](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v3..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v6)|[vs v2](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v2..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v6)|[vs v1](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v1..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v6)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v6)|
|v5||[vs v4](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v4..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v5)|[vs v3](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v3..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v5)|[vs v2](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v2..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v5)|[vs v1](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v1..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v5)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v5)|
|v4|||[vs v3](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v3..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v4)|[vs v2](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v2..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v4)|[vs v1](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v1..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v4)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v4)|
|v3||||[vs v2](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v2..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v3)|[vs v1](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v1..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v3)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v3)|
|v2|||||[vs v1](/joshlf/gherrit/compare/gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v1..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v2)|
|v1||||||[vs Base](/joshlf/gherrit/compare/main..gherrit/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu && git checkout -b pr-Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gvcjm5tfw4rdtxneq5vsmp4kss7gsanbu", "parent": null, "child": "Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu"}" -->