### PR TITLE
[tests] Ensure amends create new commits

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -188,7 +188,7 @@ fn test_version_increment() {
     assert!(v1_count > 0, "Expected v1 tag to be pushed");
 
     // Amend commit (modifies SHA, keeps Change-ID)
-    ctx.run_git(&["commit", "--amend", "--allow-empty", "--no-edit"]);
+    ctx.amend();
 
     // Push 2 (v2)
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "version_increment_v2");
@@ -240,7 +240,7 @@ fn test_optimistic_locking_conflict() {
     // quickly. We MUST preserve the Change-ID to simulate an update to the SAME
     // stack.
     let new_msg = format!("Commit V1 (Amended)\n\ngherrit-pr-id: {}", gherrit_id);
-    ctx.run_git(&["commit", "--amend", "--allow-empty", "-m", &new_msg]);
+    ctx.amend_with_message(&new_msg);
 
     // Attempt push - should fail due to atomic lock
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "optimistic_locking_v2_fail");
@@ -281,7 +281,7 @@ fn test_pr_body_generation() {
     ctx.run_git(&["checkout", "feature-stack"]); // Ensure we are on the branch
 
     // Amend "Commit B" (via tip Commit C) to create v2
-    ctx.run_git(&["commit", "--amend", "--allow-empty", "--no-edit"]);
+    ctx.amend();
 
     // Sync again
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "pr_body_generation_v2");
@@ -365,7 +365,7 @@ fn test_public_stack_links() {
     ctx.run_git(&["config", "branch.public-feature.pushRemote", "origin"]);
 
     // Force an update so the body regenerates (amend commit)
-    ctx.run_git(&["commit", "--amend", "--allow-empty", "--no-edit"]);
+    ctx.amend();
     testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "public_stack_links_public");
 
     testutil::assert_pr_snapshot!(ctx, "public_stack_links_public_state");

--- a/tests/prevent_push_to_closed_pr.rs
+++ b/tests/prevent_push_to_closed_pr.rs
@@ -16,7 +16,7 @@ fn verify_push_to_non_open_fail(state_arg: &str, expected_msg_part: &str) {
     });
 
     // 3. Amend and Push (Should Fail)
-    ctx.run_git(&["commit", "--amend", "--allow-empty", "--no-edit"]);
+    ctx.amend();
     ctx.hook("pre-push").assert().failure().stderr(predicate::str::contains(expected_msg_part));
 
     // 4. Verify no new push happened
@@ -53,7 +53,7 @@ fn test_push_to_open_pr_succeeds() {
     ctx.gherrit().args(["hook", "pre-push"]).assert().success();
 
     // 2. Amend
-    ctx.run_git(&["commit", "--amend", "--allow-empty", "--no-edit"]);
+    ctx.amend();
 
     // 3. Second Push (Should Succeed)
     ctx.gherrit().args(["hook", "pre-push"]).assert().success();

--- a/tests/regression_batch_update_failure.rs
+++ b/tests/regression_batch_update_failure.rs
@@ -13,13 +13,7 @@ fn test_regression_batch_update_silent_failure() {
     //
     // Simulate failure by appending special token "TRIGGER_GRAPHQL_NULL" to the
     // body.
-    ctx.run_git(&[
-        "commit",
-        "--amend",
-        "--allow-empty",
-        "-m",
-        "Initial Work\n\nTRIGGER_GRAPHQL_NULL",
-    ]);
+    ctx.amend_with_message("Initial Work\n\nTRIGGER_GRAPHQL_NULL");
 
     // 3. Push again - Expect Failure due to null response
     let assert = ctx.gherrit().args(["hook", "pre-push"]).assert().failure();

--- a/tests/reproduce_status_bugs.rs
+++ b/tests/reproduce_status_bugs.rs
@@ -31,7 +31,7 @@ fn test_pre_push_edit_failure() {
     ctx.gherrit().args(["hook", "pre-push"]).assert().success();
 
     // Amend commit to trigger update (edit)
-    ctx.run_git(&["commit", "--amend", "--allow-empty", "-m", "Initial Work (Updated)"]);
+    ctx.amend_with_message("Initial Work (Updated)");
 
     // Run hook with failure injection
     ctx.inject_failure(testutil::FailureKind::UpdatePr);

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -2,7 +2,10 @@ use std::{
     env, fs,
     path::{Path, PathBuf},
     process::Command,
-    sync::{Arc, LazyLock, RwLock},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, LazyLock, RwLock,
+    },
 };
 
 use regex::Regex;
@@ -14,6 +17,8 @@ pub const DEFAULT_OWNER: &str = "owner";
 pub const DEFAULT_REPO: &str = "repo";
 pub const MANAGED_PRIVATE: &str = "managedPrivate";
 pub const MANAGED_PUBLIC: &str = "managedPublic";
+
+const FIRST_GIT_TIMESTAMP: u64 = 946_684_800;
 
 #[macro_export]
 macro_rules! test_context {
@@ -182,6 +187,7 @@ impl TestContextBuilder {
             is_live,
             system_git: system_git.clone(),
             gherrit_bin_path: gherrit_bin.clone(),
+            next_git_timestamp: AtomicU64::new(FIRST_GIT_TIMESTAMP),
             mock_server,
             mock_server_state,
         };
@@ -205,6 +211,7 @@ pub struct TestContext {
     pub is_live: bool,
     pub system_git: PathBuf,
     pub gherrit_bin_path: PathBuf,
+    next_git_timestamp: AtomicU64,
     pub mock_server: Option<MockServerInfo>,
     pub mock_server_state: Option<Arc<RwLock<mock_server::MockState>>>,
 }
@@ -232,9 +239,12 @@ impl Drop for TestContext {
 
 impl TestContext {
     fn configure_mock_env(&self, cmd: &mut assert_cmd::Command) {
-        // Enforce deterministic timestamps for git commits to ensure stable IDs in snapshots
-        cmd.env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z");
-        cmd.env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z");
+        // Give each command a deterministic, unique timestamp. In particular,
+        // this ensures an otherwise-empty amend creates a distinct Git object.
+        let timestamp = self.next_git_timestamp.fetch_add(1, Ordering::Relaxed);
+        let git_date = format!("@{timestamp} +0000");
+        cmd.env("GIT_AUTHOR_DATE", &git_date);
+        cmd.env("GIT_COMMITTER_DATE", &git_date);
 
         if !self.is_live {
             // Prepend temp dir to PATH so 'gh' and 'git' resolve to our mock
@@ -297,6 +307,45 @@ impl TestContext {
 
     pub fn commit(&self, msg: &str) {
         self.run_git(&["commit", "--allow-empty", "-m", msg]);
+    }
+
+    pub fn amend(&self) {
+        self.amend_inner(&["--no-edit"]);
+    }
+
+    pub fn amend_with_message(&self, message: &str) {
+        let previous_id = self.gherrit_id("HEAD").ok();
+        let message = if message.lines().any(|line| line.starts_with("gherrit-pr-id: ")) {
+            message.to_string()
+        } else if let Some(id) = &previous_id {
+            format!("{message}\n\ngherrit-pr-id: {id}")
+        } else {
+            message.to_string()
+        };
+
+        self.amend_inner(&["-m", &message]);
+    }
+
+    fn amend_inner(&self, args: &[&str]) {
+        let previous_oid = self.head_oid();
+        let previous_id = self.gherrit_id("HEAD").ok();
+
+        self.git().arg("commit").arg("--amend").args(args).arg("--allow-empty").assert().success();
+
+        let amended_oid = self.head_oid();
+        assert_ne!(previous_oid, amended_oid, "Amend must create a distinct commit object");
+        if let Some(previous_id) = previous_id {
+            assert_eq!(
+                self.gherrit_id("HEAD").unwrap(),
+                previous_id,
+                "Amend must preserve the GHerrit ID"
+            );
+        }
+    }
+
+    pub fn head_oid(&self) -> String {
+        let assert = self.git().args(["rev-parse", "HEAD"]).assert().success();
+        String::from_utf8(assert.get_output().stdout.clone()).unwrap().trim().to_string()
     }
 
     pub fn checkout_new(&self, branch_name: &str) {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Every test command used the same Git timestamps, so an empty amend
could recreate the original object and leave the scenario unchanged.

Give commands deterministic monotonic timestamps and route rewrites
through helpers that require a new OID while preserving the GHerrit ID.




---

- 　  #308
- 　  #307
- 　  #306
- 　  #305
- 　  #303
- 　  #302
- 　  #301
- 　  #300
- 　  #299
- 👉 #298


**Latest Update:** v7 — [Compare vs v6](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v6..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v7)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|
|v7|[vs v6](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v6..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v7)|[vs v5](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v5..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v7)|[vs v4](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v4..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v7)|[vs v3](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v3..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v7)|[vs v2](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v2..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v7)|[vs v1](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v1..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v7)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v7)|
|v6||[vs v5](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v5..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v6)|[vs v4](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v4..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v6)|[vs v3](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v3..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v6)|[vs v2](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v2..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v6)|[vs v1](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v1..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v6)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v6)|
|v5|||[vs v4](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v4..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v5)|[vs v3](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v3..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v5)|[vs v2](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v2..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v5)|[vs v1](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v1..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v5)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v5)|
|v4||||[vs v3](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v3..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v4)|[vs v2](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v2..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v4)|[vs v1](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v1..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v4)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v4)|
|v3|||||[vs v2](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v2..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v3)|[vs v1](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v1..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v3)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v3)|
|v2||||||[vs v1](/joshlf/gherrit/compare/gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v1..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v2)|
|v1|||||||[vs Base](/joshlf/gherrit/compare/main..gherrit/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu && git checkout -b pr-Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gbcxmnnqiu6q2biwkbt7auen4l3uvzwnu", "parent": null, "child": "Ga7kzwd3lthhumpxhg4mrqmsfzpzkdsjv"}" -->