### PR TITLE
[tests] Make command outcomes explicit

### DIFF
--- a/tests/branch_config_transitions.rs
+++ b/tests/branch_config_transitions.rs
@@ -37,7 +37,7 @@ const BRANCH: &str = "feature";
 /// Helper to force the repo into a specific state
 fn setup_state(ctx: &TestContext, state: StartState) {
     // Always start with a clean branch
-    let _ = ctx.git().args(["branch", "-D", BRANCH]).output();
+    let _ = ctx.git_cmd().args(["branch", "-D", BRANCH]).output();
     ctx.checkout_new(BRANCH);
 
     let key_managed = format!("branch.{BRANCH}.gherritManaged");
@@ -170,18 +170,18 @@ fn test_branch_config_transitions() {
         let mut cmd;
         match case.cmd {
             Command::ManageDefault => {
-                cmd = ctx.manage();
+                cmd = ctx.manage_cmd();
             }
             Command::ManagePrivate => {
-                cmd = ctx.manage();
+                cmd = ctx.manage_cmd();
                 cmd.arg("--private");
             }
             Command::ManagePublic => {
-                cmd = ctx.manage();
+                cmd = ctx.manage_cmd();
                 cmd.arg("--public");
             }
             Command::Unmanage => {
-                cmd = ctx.unmanage();
+                cmd = ctx.unmanage_cmd();
             }
         }
 
@@ -189,7 +189,7 @@ fn test_branch_config_transitions() {
             cmd.arg("--force");
         }
 
-        testutil::assert_snapshot!(ctx, cmd, format!("transition_case_{}", case.id));
+        testutil::assert_success_snapshot!(ctx, cmd, format!("transition_case_{}", case.id));
 
         verify_state(&ctx, case.expected_final_state);
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,12 +5,12 @@ fn test_commit_msg_hook() {
     std::fs::write(&msg_file, "feat: my cool feature").unwrap();
 
     // Must manage the branch first so the hook runs
-    testutil::assert_snapshot!(ctx, ctx.manage(), "commit_msg_hook_manage");
+    testutil::assert_success_snapshot!(ctx, ctx.manage_cmd(), "commit_msg_hook_manage");
 
     // Run hook
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["hook", "commit-msg", msg_file.to_str().unwrap()]),
+        ctx.gherrit_cmd().args(["hook", "commit-msg", msg_file.to_str().unwrap()]),
         "commit_msg_hook_run"
     );
 
@@ -33,9 +33,9 @@ fn test_full_stack_lifecycle_mocked() {
     // Trigger Pre-Push Hook (Simulate 'git push'). We call the hook directly
     // because simulating a real 'git push' that calls the hook recursively is
     // complex in a test env.
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["hook", "pre-push"]),
+        ctx.gherrit_cmd().args(["hook", "pre-push"]),
         "full_stack_lifecycle_push"
     );
 
@@ -59,13 +59,13 @@ fn test_branch_management() {
     ctx.run_git(&["config", "branch.feature-A.pushRemote", "origin"]);
 
     // Attempt manage - should fail (drift)
-    testutil::assert_snapshot!(ctx, ctx.manage(), "branch_management_drift_warning"); // Logs warning, no change
+    testutil::assert_success_snapshot!(ctx, ctx.manage_cmd(), "branch_management_drift_warning"); // Logs warning, no change
     // Assert still unmanaged (missing key)
-    ctx.git().args(["config", "branch.feature-A.gherritManaged"]).assert().failure();
+    ctx.assert_config("branch.feature-A.gherritManaged", None);
 
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["manage", "--force"]),
+        ctx.gherrit_cmd().args(["manage", "--force"]),
         "branch_management_force_manage",
     );
 
@@ -80,17 +80,17 @@ fn test_branch_management() {
     ctx.assert_config("branch.feature-A.merge", Some("refs/heads/feature-A"));
 
     // Scenario B: Unmanage Cleanup
-    testutil::assert_snapshot!(ctx, ctx.unmanage(), "branch_management_unmanage");
+    testutil::assert_success_snapshot!(ctx, ctx.unmanage_cmd(), "branch_management_unmanage");
 
     // Assert unmanaged (key exists but is false)
     ctx.assert_config("branch.feature-A.gherritManaged", Some("false"));
 
     // Assert cleanup (keys should be unset)
-    ctx.git().args(["config", "branch.feature-A.remote"]).assert().failure();
-    ctx.git().args(["config", "branch.feature-A.merge"]).assert().failure();
+    ctx.assert_config("branch.feature-A.remote", None);
+    ctx.assert_config("branch.feature-A.merge", None);
 
     // Assert pushRemote unset
-    ctx.git().args(["config", "branch.feature-A.pushRemote"]).assert().failure();
+    ctx.assert_config("branch.feature-A.pushRemote", None);
 }
 
 #[test]
@@ -124,16 +124,16 @@ fn test_post_checkout_hook() {
 fn test_commit_msg_edge_cases() {
     let ctx = testutil::test_context!().build();
     // Ensure we are managed so the hook is active
-    testutil::assert_snapshot!(ctx, ctx.manage(), "commit_msg_edge_manage");
+    testutil::assert_success_snapshot!(ctx, ctx.manage_cmd(), "commit_msg_edge_manage");
 
     // Scenario A: Squash Commit
     let squash_msg_file = ctx.repo_path.join("SQUASH_MSG");
     let squash_content = "squash! some other commit";
     std::fs::write(&squash_msg_file, squash_content).unwrap();
 
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["hook", "commit-msg", squash_msg_file.to_str().unwrap()]),
+        ctx.gherrit_cmd().args(["hook", "commit-msg", squash_msg_file.to_str().unwrap()]),
         "commit_msg_squash",
     );
 
@@ -146,9 +146,9 @@ fn test_commit_msg_edge_cases() {
     let detached_content = "feat: detached work";
     std::fs::write(&detached_msg_file, detached_content).unwrap();
 
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["hook", "commit-msg", detached_msg_file.to_str().unwrap()]),
+        ctx.gherrit_cmd().args(["hook", "commit-msg", detached_msg_file.to_str().unwrap()]),
         "commit_msg_detached"
     );
 
@@ -169,7 +169,7 @@ fn test_pre_push_ancestry_check() {
 
     // Trigger pre-push hook; it should fail because it can't find the merge
     // base with 'main'
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "pre_push_ancestry_failure");
+    testutil::assert_failure_snapshot!(ctx, ctx.hook_cmd("pre-push"), "pre_push_ancestry_failure");
 }
 
 #[test]
@@ -181,7 +181,7 @@ fn test_version_increment() {
     ctx.commit("Feature Commit");
 
     // Push 1 (v1)
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "version_increment_v1");
+    testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "version_increment_v1");
 
     // Verify v1 pushed
     let v1_count = ctx.count_successfully_pushed_containing("/v1");
@@ -191,7 +191,7 @@ fn test_version_increment() {
     ctx.amend();
 
     // Push 2 (v2)
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "version_increment_v2");
+    testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "version_increment_v2");
 
     // Verify v2 pushed
     let v2_count = ctx.count_successfully_pushed_containing("/v2");
@@ -218,7 +218,7 @@ fn test_optimistic_locking_conflict() {
     ctx.commit("Commit V1");
 
     // Push V1
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "optimistic_locking_v1");
+    testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "optimistic_locking_v1");
 
     let gherrit_id = ctx.gherrit_id("HEAD").unwrap();
     let managed_ref = format!("refs/heads/{gherrit_id}");
@@ -230,7 +230,7 @@ fn test_optimistic_locking_conflict() {
     let tag_name = format!("gherrit/{}/v2", gherrit_id);
 
     // Create tag pointing to the branch we just pushed
-    ctx.remote_git()
+    ctx.remote_git_cmd()
         .args(["tag", &tag_name, &format!("refs/heads/{}", gherrit_id)])
         .assert()
         .success();
@@ -243,7 +243,7 @@ fn test_optimistic_locking_conflict() {
     ctx.amend_with_message(&new_msg);
 
     // Attempt push - should fail due to atomic lock
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "optimistic_locking_v2_fail");
+    testutil::assert_failure_snapshot!(ctx, ctx.hook_cmd("pre-push"), "optimistic_locking_v2_fail");
 
     ctx.maybe_inspect_mock_state(|state| {
         assert_eq!(state.pushes.len(), 2, "Expected one successful and one failed push");
@@ -272,7 +272,7 @@ fn test_pr_body_generation() {
     // We can verify this implicitly by checking the PR bodies later.
 
     // Sync
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "pr_body_generation_v1");
+    testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "pr_body_generation_v1");
 
     // Verify
     testutil::assert_pr_snapshot!(ctx, "pr_body_generation_v1_state");
@@ -284,7 +284,7 @@ fn test_pr_body_generation() {
     ctx.amend();
 
     // Sync again
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "pr_body_generation_v2");
+    testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "pr_body_generation_v2");
 
     testutil::assert_pr_snapshot!(ctx, "pr_body_generation_v2_state");
 }
@@ -303,7 +303,7 @@ fn test_large_stack_batching() {
 
     // Sync - should succeed without error
     // Using simple pre-push hook invocation.
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "large_stack_batching");
+    testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "large_stack_batching");
 
     ctx.maybe_inspect_mock_state(|state| {
         // Assert: Push was split into 2 batches (80 + 5)
@@ -341,7 +341,7 @@ fn test_rebase_detection() {
     std::fs::write(rebase_dir.join("head-name"), "refs/heads/feature-rebase").unwrap();
 
     // Run manage - should succeed by detecting 'feature-rebase'
-    testutil::assert_snapshot!(ctx, ctx.manage(), "rebase_detection_manage");
+    testutil::assert_success_snapshot!(ctx, ctx.manage_cmd(), "rebase_detection_manage");
 
     // Verify config was applied to 'feature-rebase'
     ctx.assert_config("branch.feature-rebase.gherritManaged", Some(testutil::MANAGED_PRIVATE));
@@ -356,7 +356,7 @@ fn test_public_stack_links() {
     ctx.checkout_new("public-feature");
     ctx.commit("Public Commit");
 
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "public_stack_links_private");
+    testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "public_stack_links_private");
 
     testutil::assert_pr_snapshot!(ctx, "public_stack_links_private_state");
 
@@ -366,7 +366,7 @@ fn test_public_stack_links() {
 
     // Force an update so the body regenerates (amend commit)
     ctx.amend();
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "public_stack_links_public");
+    testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "public_stack_links_public");
 
     testutil::assert_pr_snapshot!(ctx, "public_stack_links_public_state");
 }
@@ -382,14 +382,18 @@ fn test_install_command_edge_cases() {
     // Scenario A: Conflict
     std::fs::write(&pre_push, "foo").unwrap();
 
-    testutil::assert_snapshot!(ctx, ctx.gherrit().args(["install"]), "install_edge_cases_conflict");
+    testutil::assert_failure_snapshot!(
+        ctx,
+        ctx.gherrit_cmd().args(["install"]),
+        "install_edge_cases_conflict"
+    );
 
     assert_eq!(std::fs::read_to_string(&pre_push).unwrap(), "foo");
 
     // Scenario B: Force Overwrite
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["install", "--force"]),
+        ctx.gherrit_cmd().args(["install", "--force"]),
         "install_edge_cases_force"
     );
 
@@ -397,9 +401,9 @@ fn test_install_command_edge_cases() {
     assert!(content.contains("# gherrit-installer: managed"));
 
     // Scenario C: Idempotency (Safe to run again)
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["install"]),
+        ctx.gherrit_cmd().args(["install"]),
         "install_edge_cases_idempotent"
     );
 
@@ -407,7 +411,11 @@ fn test_install_command_edge_cases() {
     let modified = content + "\n# Some custom comment";
     std::fs::write(&pre_push, modified).unwrap();
 
-    testutil::assert_snapshot!(ctx, ctx.gherrit().args(["install"]), "install_edge_cases_upgrade");
+    testutil::assert_success_snapshot!(
+        ctx,
+        ctx.gherrit_cmd().args(["install"]),
+        "install_edge_cases_upgrade"
+    );
 
     // Content should be reset to standard shim (losing custom comment, which is expected behavior for managed hooks)
     let reset_content = std::fs::read_to_string(&pre_push).unwrap();
@@ -420,7 +428,7 @@ fn test_installed_pre_push_hook_accepts_git_arguments() {
     let ctx = testutil::test_context_minimal!().install_hooks(true).initial_commit(true).build();
 
     // Git invokes the pre-push hook with the remote name and location.
-    ctx.git().args(["push", "origin", "main"]).assert().success();
+    ctx.git_cmd().args(["push", "origin", "main"]).assert().success();
 }
 
 #[test]
@@ -435,7 +443,11 @@ fn test_install_configuration_and_security() {
         std::fs::remove_dir_all(&default_hooks).unwrap();
     }
 
-    testutil::assert_snapshot!(ctx, ctx.gherrit().args(["install"]), "install_security_default");
+    testutil::assert_success_snapshot!(
+        ctx,
+        ctx.gherrit_cmd().args(["install"]),
+        "install_security_default"
+    );
     assert!(default_hooks.join("pre-push").exists(), "Should create directory and install hook");
 
     // Scenario B: Custom core.hooksPath (Internal)
@@ -443,9 +455,9 @@ fn test_install_configuration_and_security() {
     let custom_internal = ctx.repo_path.join(".githooks");
     ctx.run_git(&["config", "core.hooksPath", ".githooks"]);
 
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["install"]),
+        ctx.gherrit_cmd().args(["install"]),
         "install_security_custom_internal"
     );
     assert!(custom_internal.join("pre-push").exists(), "Should respect core.hooksPath within repo");
@@ -458,9 +470,9 @@ fn test_install_configuration_and_security() {
     // We must use absolute path for git config to ensure gherrit sees it as external
     ctx.run_git(&["config", "core.hooksPath", ext_path]);
 
-    testutil::assert_snapshot!(
+    testutil::assert_failure_snapshot!(
         ctx,
-        ctx.gherrit().args(["install"]), // Should fail
+        ctx.gherrit_cmd().args(["install"]), // Should fail
         "install_security_custom_external_block",
         &[(ext_path, "[EXTERNAL_HOOKS_PATH]")]
     );
@@ -472,9 +484,9 @@ fn test_install_configuration_and_security() {
 
     // Scenario D: Custom core.hooksPath (External) - Allow Global
     // -----------------------------------------------------------
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["install", "--allow-global"]),
+        ctx.gherrit_cmd().args(["install", "--allow-global"]),
         "install_security_custom_external_allow",
         &[(ext_path, "[EXTERNAL_HOOKS_PATH]")],
     );
@@ -494,7 +506,7 @@ fn test_manage_detached_head() {
     ctx.run_git(&["checkout", "--detach"]);
 
     let test = |args: &[_], name| {
-        testutil::assert_snapshot!(ctx, ctx.gherrit().args(args), name);
+        testutil::assert_failure_snapshot!(ctx, ctx.gherrit_cmd().args(args), name);
     };
 
     test(&["manage"], "manage_detached_head");
@@ -516,11 +528,11 @@ fn test_unmanage_cleanup_logic() {
     ctx.run_git(&["config", "branch.feature-cleanup.merge", "refs/heads/feature-cleanup"]);
 
     // Run unmanage
-    testutil::assert_snapshot!(ctx, ctx.unmanage(), "unmanage_cleanup");
+    testutil::assert_success_snapshot!(ctx, ctx.unmanage_cmd(), "unmanage_cleanup");
 
     // Verify cleanup: remote and merge keys should be removed
-    ctx.git().args(["config", "branch.feature-cleanup.remote"]).assert().failure();
-    ctx.git().args(["config", "branch.feature-cleanup.merge"]).assert().failure();
+    ctx.assert_config("branch.feature-cleanup.remote", None);
+    ctx.assert_config("branch.feature-cleanup.merge", None);
     // gherritManaged should be false
     ctx.assert_config("branch.feature-cleanup.gherritManaged", Some("false"));
 }
@@ -537,7 +549,11 @@ fn test_pre_push_failure() {
     ctx.run_git(&["remote", "add", "broken-remote", "/path/to/nowhere"]);
     ctx.run_git(&["config", "gherrit.remote", "broken-remote"]);
 
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "pre_push_failure_broken_remote");
+    testutil::assert_failure_snapshot!(
+        ctx,
+        ctx.hook_cmd("pre-push"),
+        "pre_push_failure_broken_remote"
+    );
 }
 
 #[test]
@@ -561,7 +577,11 @@ fn test_install_read_only_fs() {
     std::fs::set_permissions(&hooks_dir, perms).unwrap();
 
     // Attempt installation, verifying failure due to permission denied
-    testutil::assert_snapshot!(ctx, ctx.gherrit().args(["install"]), "install_read_only_fs");
+    testutil::assert_failure_snapshot!(
+        ctx,
+        ctx.gherrit_cmd().args(["install"]),
+        "install_read_only_fs"
+    );
 
     // Cleanup: Restore permissions so TempDir cleanup doesn't panic
     let mut perms = std::fs::metadata(&hooks_dir).unwrap().permissions();
@@ -575,9 +595,9 @@ fn test_manage_drift_detection() {
     ctx.checkout_new("drift-feature");
 
     // 1. Initialize managed private branch
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["manage", "--private"]),
+        ctx.gherrit_cmd().args(["manage", "--private"]),
         "manage_drift_init"
     );
 
@@ -586,9 +606,9 @@ fn test_manage_drift_detection() {
 
     // 3. Attempt Switch to Public (without force)
     // The command should exit with 0 but log a warning and NOT apply changes.
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["manage", "--public"]),
+        ctx.gherrit_cmd().args(["manage", "--public"]),
         "manage_drift_attempt_switch"
     );
 
@@ -596,9 +616,9 @@ fn test_manage_drift_detection() {
     ctx.assert_config("branch.drift-feature.gherritManaged", Some(testutil::MANAGED_PRIVATE));
 
     // 4. Force Switch
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["manage", "--public", "--force"]),
+        ctx.gherrit_cmd().args(["manage", "--public", "--force"]),
         "manage_drift_force_switch",
     );
 
@@ -615,25 +635,25 @@ fn test_manage_toggle_visibility() {
     ctx.checkout_new("visibility-feature");
 
     // 1. Private
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["manage", "--private"]),
+        ctx.gherrit_cmd().args(["manage", "--private"]),
         "manage_toggle_init_private"
     );
     ctx.assert_config("branch.visibility-feature.pushRemote", Some("."));
 
     // 2. Public
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["manage", "--public"]),
+        ctx.gherrit_cmd().args(["manage", "--public"]),
         "manage_toggle_switch_public"
     );
     ctx.assert_config("branch.visibility-feature.pushRemote", Some("origin"));
 
     // 3. Private again
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.gherrit().args(["manage", "--private"]),
+        ctx.gherrit_cmd().args(["manage", "--private"]),
         "manage_toggle_switch_private",
     );
     ctx.assert_config("branch.visibility-feature.pushRemote", Some("."));
@@ -645,9 +665,9 @@ fn test_manage_mutually_exclusive_flags() {
     ctx.checkout_new("conflict-feature");
 
     // Attempt to set both flags
-    testutil::assert_snapshot!(
+    testutil::assert_failure_snapshot!(
         ctx,
-        ctx.gherrit().args(["manage", "--public", "--private"]),
+        ctx.gherrit_cmd().args(["manage", "--public", "--private"]),
         "manage_mutually_exclusive",
     );
 }
@@ -661,7 +681,7 @@ fn test_manage_invalid_config() {
     ctx.run_git(&["config", "branch.invalid-config-feature.gherritManaged", "bad-value"]);
 
     // Attempt to manage; should fail
-    testutil::assert_snapshot!(ctx, ctx.manage(), "manage_invalid_config");
+    testutil::assert_failure_snapshot!(ctx, ctx.manage_cmd(), "manage_invalid_config");
 }
 
 #[test]
@@ -673,9 +693,9 @@ fn test_post_checkout_drift_detection() {
     ctx.run_git(&["update-ref", "refs/remotes/origin/drift-shared", "HEAD"]);
 
     // Switch to new tracking branch - this triggers post-checkout
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.git().args(["checkout", "-b", "drift-shared", "--track", "origin/drift-shared"]),
+        ctx.git_cmd().args(["checkout", "-b", "drift-shared", "--track", "origin/drift-shared"]),
         "post_checkout_drift_shared",
     );
 
@@ -686,9 +706,9 @@ fn test_post_checkout_drift_detection() {
     ctx.run_git(&["config", "branch.drift-stack.remote", "origin"]);
 
     // Switch to it
-    testutil::assert_snapshot!(
+    testutil::assert_success_snapshot!(
         ctx,
-        ctx.git().args(["checkout", "drift-stack"]),
+        ctx.git_cmd().args(["checkout", "drift-stack"]),
         "post_checkout_drift_stack"
     );
 }

--- a/tests/migration_edge_cases.rs
+++ b/tests/migration_edge_cases.rs
@@ -2,8 +2,8 @@
 fn test_mixed_stack_backward_compatibility() {
     let ctx = testutil::test_context!().build();
 
-    ctx.manage(); // Ensure hooks are active
-    ctx.checkout_new("mixed-stack"); // Checkout new to enable management on this branch
+    // Checking out a new branch enables management through the installed hook.
+    ctx.checkout_new("mixed-stack");
 
     // 1. Create a commit with a manual Hex ID (legacy format)
     let legacy_id = "G0000000000000000000000000000000000000001";
@@ -17,7 +17,11 @@ fn test_mixed_stack_backward_compatibility() {
     // We expect this to succeed and identify 2 commits to sync.
     // The "snapshot" will serve as verification of the output containing both IDs if we were looking at it,
     // but here we mainly care that it doesn't crash and processes both.
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "mixed_stack_backward_compatibility");
+    testutil::assert_success_snapshot!(
+        ctx,
+        ctx.hook_cmd("pre-push"),
+        "mixed_stack_backward_compatibility"
+    );
 
     let legacy_ref = format!("refs/heads/{legacy_id}");
     assert!(ctx.remote_ref_oid(&legacy_ref).is_some(), "Expected legacy ID to be pushed");
@@ -26,12 +30,11 @@ fn test_mixed_stack_backward_compatibility() {
 #[test]
 fn test_base32_format_compliance() {
     let ctx = testutil::test_context!().build();
-    ctx.manage();
     ctx.checkout_new("base32-format");
     ctx.commit("Base32 Commit");
 
     // Read the commit message
-    let output = ctx.git().args(["log", "-1", "--format=%B"]).output().unwrap();
+    let output = ctx.git_cmd().args(["log", "-1", "--format=%B"]).output().unwrap();
     let msg = String::from_utf8(output.stdout).unwrap();
 
     // extract ID

--- a/tests/pre_push_autosquash.rs
+++ b/tests/pre_push_autosquash.rs
@@ -38,7 +38,7 @@ fn test_autosquash_prefixes() {
         // Prefix commit
         ctx.commit(&format!("{} Work in progress", prefix));
 
-        let output = ctx.gherrit().args(["hook", "pre-push"]).assert();
+        let output = ctx.gherrit_cmd().args(["hook", "pre-push"]).assert();
         assert_autosquash_error(output, "origin", "main");
     }
 }
@@ -67,7 +67,7 @@ fn test_buried_autosquash_commit() {
     // 3. Commit C (Normal)
     ctx.commit("Commit C");
 
-    let output = ctx.gherrit().args(["hook", "pre-push"]).assert();
+    let output = ctx.gherrit_cmd().args(["hook", "pre-push"]).assert();
     assert_autosquash_error(output, "origin", "main");
 }
 
@@ -90,7 +90,7 @@ fn test_precedence_over_trailer_check() {
     let msg = "fixup! Some feature\n\ngherrit-pr-id: G12345";
     ctx.commit(msg);
 
-    let output = ctx.gherrit().args(["hook", "pre-push"]).assert();
+    let output = ctx.gherrit_cmd().args(["hook", "pre-push"]).assert();
 
     // Must fail with autosquash error, NOT missing trailer error
     assert_autosquash_error(output, "origin", "main")
@@ -143,7 +143,7 @@ fn test_dynamic_remote_and_branch_suggestion() {
     // Create fixup
     ctx.commit("fixup! Work");
 
-    let output = ctx.gherrit().args(["hook", "pre-push"]).assert();
+    let output = ctx.gherrit_cmd().args(["hook", "pre-push"]).assert();
 
     assert_autosquash_error(output, "upstream", "master");
 }
@@ -160,5 +160,5 @@ fn test_valid_stack_passes() {
     ctx.commit("Commit B");
     ctx.commit("Commit C");
 
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
 }

--- a/tests/prevent_push_to_closed_pr.rs
+++ b/tests/prevent_push_to_closed_pr.rs
@@ -6,7 +6,7 @@ fn verify_push_to_non_open_fail(state_arg: &str, expected_msg_part: &str) {
 
     // 1. Initial Push (Creates PR)
     ctx.commit("Initial Work");
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
     let refs_before_rejected_push = ctx.remote_refs("refs");
 
     // 2. Simulate PR State Change on GitHub
@@ -17,7 +17,7 @@ fn verify_push_to_non_open_fail(state_arg: &str, expected_msg_part: &str) {
 
     // 3. Amend and Push (Should Fail)
     ctx.amend();
-    ctx.hook("pre-push").assert().failure().stderr(predicate::str::contains(expected_msg_part));
+    ctx.hook_cmd("pre-push").assert().failure().stderr(predicate::str::contains(expected_msg_part));
 
     // 4. Verify no new push happened
     let name = format!("prevent_push_to_{}_pr_state", state_arg.to_lowercase());
@@ -50,11 +50,11 @@ fn test_push_to_open_pr_succeeds() {
     ctx.commit("Work");
 
     // 1. First Push
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
 
     // 2. Amend
     ctx.amend();
 
     // 3. Second Push (Should Succeed)
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
 }

--- a/tests/regression_batch_update_failure.rs
+++ b/tests/regression_batch_update_failure.rs
@@ -7,7 +7,7 @@ fn test_regression_batch_update_silent_failure() {
 
     // 1. Initial Push (creates PR)
     ctx.commit("Initial Work");
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
 
     // 2. Modify commit to trigger failure in mock server
     //
@@ -16,7 +16,7 @@ fn test_regression_batch_update_silent_failure() {
     ctx.amend_with_message("Initial Work\n\nTRIGGER_GRAPHQL_NULL");
 
     // 3. Push again - Expect Failure due to null response
-    let assert = ctx.gherrit().args(["hook", "pre-push"]).assert().failure();
+    let assert = ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().failure();
 
     assert.stderr(predicate::str::contains("The batched GraphQL mutation failed to update PR"));
 }

--- a/tests/reproduce_issue.rs
+++ b/tests/reproduce_issue.rs
@@ -23,12 +23,12 @@ fn test_special_characters_in_repo_url() {
         ctx.checkout_new("feature-stack");
 
         // Manage must happen before commit to ensure the commit-msg hook adds the trailer
-        ctx.manage().assert().success();
+        ctx.manage_cmd().assert().success();
 
         ctx.run_git(&["commit", "--allow-empty", "-m", "Commit A"]);
 
         // Run pre-push hook
         // This fails if the regex doesn't match the generated URL
-        ctx.hook("pre-push").assert().success();
+        ctx.hook_cmd("pre-push").assert().success();
     }
 }

--- a/tests/reproduce_merge_queue_failure.rs
+++ b/tests/reproduce_merge_queue_failure.rs
@@ -10,7 +10,7 @@ fn test_reproduce_merge_queue_failure() {
     // 1. Create a PR
     ctx.checkout_new("feature-branch");
     ctx.commit("Initial Feature Work");
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
 
     // Get the PR ID
     let mut pr_id = 0;
@@ -27,5 +27,5 @@ fn test_reproduce_merge_queue_failure() {
     ctx.commit("Initial Feature Work (Amended)");
 
     // 4. Push again
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
 }

--- a/tests/reproduce_pagination_bug.rs
+++ b/tests/reproduce_pagination_bug.rs
@@ -7,7 +7,7 @@ fn test_pagination_bug() {
 
     // 2. Checkout feature branch and manage it
     ctx.checkout_new("feature");
-    ctx.gherrit().args(["manage", "--force"]).assert().success();
+    ctx.gherrit_cmd().args(["manage", "--force"]).assert().success();
 
     // 3. Create a commit with a known Change-Id
     let change_id = "I0000000000000000000000000000000000000105";
@@ -35,14 +35,14 @@ fn test_pagination_bug() {
     });
 
     // 5. Run gherrit hook pre-push
-    let assert = ctx.gherrit().args(["hook", "pre-push"]).env("RUST_LOG", "debug").assert();
+    let assert =
+        ctx.gherrit_cmd().args(["hook", "pre-push"]).env("RUST_LOG", "debug").assert().success();
 
     let output = assert.get_output();
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    println!("Stderr: {}", stderr);
-
-    if !stderr.contains("Found existing PR #105") {
-        panic!("Regression: Failed to find PR #105 (likely pagination bug). Logs:\n{}", stderr);
-    }
+    assert!(
+        stderr.contains("Found existing PR #105"),
+        "Regression: Failed to find PR #105 (likely pagination bug). Logs:\n{stderr}"
+    );
 }

--- a/tests/reproduce_pr_base_bug.rs
+++ b/tests/reproduce_pr_base_bug.rs
@@ -9,7 +9,7 @@ fn test_reproduce_pr_base_branch_bug() {
     ctx.checkout_new("feature-branch");
     ctx.commit("Feature Work");
 
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
 
     testutil::assert_pr_snapshot!(ctx, "reproduce_pr_base_bug_state");
 }

--- a/tests/reproduce_status_bugs.rs
+++ b/tests/reproduce_status_bugs.rs
@@ -6,7 +6,7 @@ fn test_commit_msg_trailer_failure() {
     let ctx = testutil::test_context_minimal!().install_hooks(true).build();
 
     // Manage branch to enable hook
-    ctx.gherrit().args(["manage"]).assert().success();
+    ctx.gherrit_cmd().args(["manage"]).assert().success();
 
     let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");
     std::fs::write(&msg_file, "feat: broken trailers").unwrap();
@@ -17,7 +17,12 @@ fn test_commit_msg_trailer_failure() {
     std::fs::set_permissions(&msg_file, perms).unwrap();
 
     // Hook should fail if it can't write trailer
-    ctx.gherrit().args(["hook", "commit-msg", msg_file.to_str().unwrap()]).assert().failure();
+    ctx.gherrit_cmd()
+        .args(["hook", "commit-msg", msg_file.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("is not writable by user"));
+    assert_eq!(std::fs::read_to_string(&msg_file).unwrap(), "feat: broken trailers");
 }
 
 #[test]
@@ -28,7 +33,7 @@ fn test_pre_push_edit_failure() {
     ctx.checkout_new("feature-edit-fail");
     ctx.commit("Initial Work");
     // Initial push creates PR
-    ctx.gherrit().args(["hook", "pre-push"]).assert().success();
+    ctx.gherrit_cmd().args(["hook", "pre-push"]).assert().success();
 
     // Amend commit to trigger update (edit)
     ctx.amend_with_message("Initial Work (Updated)");
@@ -36,5 +41,22 @@ fn test_pre_push_edit_failure() {
     // Run hook with failure injection
     ctx.inject_failure(testutil::FailureKind::UpdatePr);
 
-    ctx.gherrit().args(["hook", "pre-push"]).assert().failure();
+    ctx.gherrit_cmd()
+        .args(["hook", "pre-push"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Injected UpdatePr failure"));
+    ctx.assert_failure_consumed();
+    ctx.maybe_inspect_mock_state(|state| {
+        assert_eq!(
+            state.graphql_requests.last(),
+            Some(&vec![testutil::mock_server::GraphQlOperation::UpdatePr])
+        );
+        assert_eq!(state.prs.len(), 1);
+        assert_eq!(state.prs[0].title.as_deref(), Some("Initial Work"));
+    });
+
+    let gherrit_id = ctx.gherrit_id("HEAD").unwrap();
+    let remote_ref = format!("refs/heads/{gherrit_id}");
+    assert_eq!(ctx.remote_ref_oid(&remote_ref).as_deref(), Some(ctx.head_oid().as_str()));
 }

--- a/tests/reproduce_unchecked_output_bugs.rs
+++ b/tests/reproduce_unchecked_output_bugs.rs
@@ -8,7 +8,7 @@ fn test_pre_push_ls_remote_failure() {
     ctx.commit("Work");
 
     // Hook should succeed but warn about ls-remote failure
-    ctx.gherrit()
+    ctx.gherrit_cmd()
         .args(["hook", "pre-push"])
         .env("MOCK_BIN_FAIL_CMD", "git:ls-remote")
         .assert()
@@ -25,7 +25,20 @@ fn test_pre_push_pr_list_failure() {
     // Trigger hook
     ctx.inject_failure(testutil::FailureKind::GraphQl);
 
-    ctx.gherrit().args(["hook", "pre-push"]).assert().failure();
+    ctx.gherrit_cmd()
+        .args(["hook", "pre-push"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Injected GraphQl failure"));
+    ctx.assert_failure_consumed();
+    ctx.maybe_inspect_mock_state(|state| {
+        assert_eq!(
+            state.graphql_requests,
+            vec![vec![testutil::mock_server::GraphQlOperation::Query]]
+        );
+        assert!(state.prs.is_empty());
+        assert!(state.pushes.is_empty());
+    });
 }
 
 #[test]
@@ -37,7 +50,20 @@ fn test_pre_push_pr_create_failure() {
     // Trigger hook
     ctx.inject_failure(testutil::FailureKind::CreatePr);
 
-    ctx.gherrit().args(["hook", "pre-push"]).assert().failure();
+    ctx.gherrit_cmd()
+        .args(["hook", "pre-push"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Injected CreatePr failure"));
+    ctx.assert_failure_consumed();
+    ctx.maybe_inspect_mock_state(|state| {
+        assert_eq!(
+            state.graphql_requests.last(),
+            Some(&vec![testutil::mock_server::GraphQlOperation::CreatePr])
+        );
+        assert!(state.prs.is_empty());
+        assert_eq!(state.pushes.iter().filter(|push| push.succeeded()).count(), 1);
+    });
 }
 
 #[test]
@@ -45,16 +71,17 @@ fn test_commit_msg_git_var_failure() {
     #[cfg(unix)]
     {
         let ctx = testutil::test_context_minimal!().install_hooks(true).build();
-        ctx.gherrit().args(["manage"]).assert().success();
+        ctx.gherrit_cmd().args(["manage"]).assert().success();
 
         let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");
         std::fs::write(&msg_file, "feat: broken git var").unwrap();
 
-        ctx.gherrit()
+        ctx.gherrit_cmd()
             .args(["hook", "commit-msg", msg_file.to_str().unwrap()])
             .env("MOCK_BIN_FAIL_CMD", "git:var")
             .assert()
-            .failure();
+            .failure()
+            .stderr(predicate::str::contains("Simulated failure for git var"));
     }
 }
 
@@ -63,15 +90,16 @@ fn test_commit_msg_trailers_failure() {
     #[cfg(unix)]
     {
         let ctx = testutil::test_context_minimal!().install_hooks(true).build();
-        ctx.gherrit().args(["manage"]).assert().success();
+        ctx.gherrit_cmd().args(["manage"]).assert().success();
 
         let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");
         std::fs::write(&msg_file, "feat: broken trailers parse").unwrap();
 
-        ctx.gherrit()
+        ctx.gherrit_cmd()
             .args(["hook", "commit-msg", msg_file.to_str().unwrap()])
             .env("MOCK_BIN_FAIL_CMD", "git:interpret-trailers")
             .assert()
-            .failure();
+            .failure()
+            .stderr(predicate::str::contains("Simulated failure for git interpret-trailers"));
     }
 }

--- a/tests/reproduce_unmanaged_sync.rs
+++ b/tests/reproduce_unmanaged_sync.rs
@@ -14,7 +14,11 @@ fn test_reproduce_unmanaged_sync() {
     ctx.set_config("branch.explicit-unmanaged.gherritManaged", Some("false"));
     ctx.commit("Explicit Commit");
 
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "reproduce_unmanaged_sync_explicit");
+    testutil::assert_success_snapshot!(
+        ctx,
+        ctx.hook_cmd("pre-push"),
+        "reproduce_unmanaged_sync_explicit"
+    );
 
     testutil::assert_pr_snapshot!(ctx, "reproduce_unmanaged_sync_explicit_state");
 
@@ -23,7 +27,11 @@ fn test_reproduce_unmanaged_sync() {
     ctx.set_config("branch.implicit-unmanaged.gherritManaged", None);
     ctx.run_git(&["commit", "--allow-empty", "-m", "Implicit Commit", "--no-verify"]);
 
-    testutil::assert_snapshot!(ctx, ctx.hook("pre-push"), "reproduce_unmanaged_sync_implicit");
+    testutil::assert_failure_snapshot!(
+        ctx,
+        ctx.hook_cmd("pre-push"),
+        "reproduce_unmanaged_sync_implicit"
+    );
 
     testutil::assert_pr_snapshot!(ctx, "reproduce_unmanaged_sync_implicit_state");
 }

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -262,7 +262,8 @@ impl TestContext {
         }
     }
 
-    pub fn gherrit(&self) -> assert_cmd::Command {
+    #[must_use = "command builders do nothing until executed"]
+    pub fn gherrit_cmd(&self) -> assert_cmd::Command {
         // Use injected binary path
         let mut cmd = assert_cmd::Command::new(&self.gherrit_bin_path);
         cmd.current_dir(&self.repo_path);
@@ -279,7 +280,8 @@ impl TestContext {
         cmd
     }
 
-    pub fn remote_git(&self) -> assert_cmd::Command {
+    #[must_use = "command builders do nothing until executed"]
+    pub fn remote_git_cmd(&self) -> assert_cmd::Command {
         let mut cmd = assert_cmd::Command::new(&self.system_git);
         cmd.current_dir(&self.remote_path);
         self.configure_mock_env(&mut cmd);
@@ -287,10 +289,11 @@ impl TestContext {
     }
 
     pub fn run_git(&self, args: &[&str]) {
-        self.git().args(args).assert().success();
+        self.git_cmd().args(args).assert().success();
     }
 
-    pub fn git(&self) -> assert_cmd::Command {
+    #[must_use = "command builders do nothing until executed"]
+    pub fn git_cmd(&self) -> assert_cmd::Command {
         let mut cmd = assert_cmd::Command::new("git");
         cmd.current_dir(&self.repo_path);
         self.configure_mock_env(&mut cmd);
@@ -303,7 +306,7 @@ impl TestContext {
 
     pub fn install_hooks(&self) {
         // Use the new install command
-        self.gherrit().args(["install"]).assert().success();
+        self.gherrit_cmd().args(["install"]).assert().success();
     }
 
     pub fn commit(&self, msg: &str) {
@@ -331,7 +334,13 @@ impl TestContext {
         let previous_oid = self.head_oid();
         let previous_id = self.gherrit_id("HEAD").ok();
 
-        self.git().arg("commit").arg("--amend").args(args).arg("--allow-empty").assert().success();
+        self.git_cmd()
+            .arg("commit")
+            .arg("--amend")
+            .args(args)
+            .arg("--allow-empty")
+            .assert()
+            .success();
 
         let amended_oid = self.head_oid();
         assert_ne!(previous_oid, amended_oid, "Amend must create a distinct commit object");
@@ -345,7 +354,7 @@ impl TestContext {
     }
 
     pub fn head_oid(&self) -> String {
-        let assert = self.git().args(["rev-parse", "HEAD"]).assert().success();
+        let assert = self.git_cmd().args(["rev-parse", "HEAD"]).assert().success();
         String::from_utf8(assert.get_output().stdout.clone()).unwrap().trim().to_string()
     }
 
@@ -358,6 +367,16 @@ impl TestContext {
             self.mock_server_state.as_ref().expect("Mock state not available").write().unwrap();
 
         state.fail_next_request = Some(kind);
+    }
+
+    pub fn assert_failure_consumed(&self) {
+        self.maybe_inspect_mock_state(|state| {
+            assert!(
+                state.fail_next_request.is_none(),
+                "Expected injected failure to be consumed, but {:?} remains",
+                state.fail_next_request
+            );
+        });
     }
 
     pub fn maybe_inspect_mock_state(&self, f: impl FnOnce(&mock_server::MockState)) {
@@ -386,7 +405,7 @@ impl TestContext {
 
     pub fn remote_ref_oid(&self, ref_name: &str) -> Option<String> {
         let output = self
-            .remote_git()
+            .remote_git_cmd()
             .args(["rev-parse", "--verify", "--quiet", ref_name])
             .output()
             .expect("Failed to inspect remote ref");
@@ -399,7 +418,7 @@ impl TestContext {
 
     pub fn remote_refs(&self, prefix: &str) -> Vec<String> {
         let assert = self
-            .remote_git()
+            .remote_git_cmd()
             .args(["for-each-ref", "--format=%(refname)", prefix])
             .assert()
             .success();
@@ -426,41 +445,57 @@ impl TestContext {
 
     pub fn set_config(&self, key: &str, value: Option<&str>) {
         if let Some(val) = value {
-            self.git().args(["config", key, val]).assert().success();
+            self.git_cmd().args(["config", key, val]).assert().success();
         } else {
-            // Ignore error if key doesn't exist when unsetting
-            let _ = self.git().args(["config", "--unset", key]).output();
+            let output = self
+                .git_cmd()
+                .args(["config", "--get-all", key])
+                .output()
+                .expect("Failed to inspect Git config");
+            match output.status.code() {
+                Some(0) => {
+                    self.git_cmd().args(["config", "--unset-all", key]).assert().success();
+                }
+                Some(1) => {}
+                code => panic!(
+                    "Failed to inspect Git config {key:?} with exit code {code:?}: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ),
+            }
         }
     }
 
     pub fn assert_config(&self, key: &str, expected_value: Option<&str>) {
         if let Some(val) = expected_value {
-            self.git().args(["config", key]).assert().success().stdout(format!("{}\n", val));
+            self.git_cmd().args(["config", key]).assert().success().stdout(format!("{}\n", val));
         } else {
-            self.git().args(["config", key]).assert().failure();
+            self.git_cmd().args(["config", key]).assert().code(1).stdout("");
         }
     }
 
-    pub fn hook(&self, name: &str) -> assert_cmd::Command {
-        let mut cmd = self.gherrit();
+    #[must_use = "command builders do nothing until executed"]
+    pub fn hook_cmd(&self, name: &str) -> assert_cmd::Command {
+        let mut cmd = self.gherrit_cmd();
         cmd.args(["hook", name]);
         cmd
     }
 
-    pub fn manage(&self) -> assert_cmd::Command {
-        let mut cmd = self.gherrit();
+    #[must_use = "command builders do nothing until executed"]
+    pub fn manage_cmd(&self) -> assert_cmd::Command {
+        let mut cmd = self.gherrit_cmd();
         cmd.arg("manage");
         cmd
     }
 
-    pub fn unmanage(&self) -> assert_cmd::Command {
-        let mut cmd = self.gherrit();
+    #[must_use = "command builders do nothing until executed"]
+    pub fn unmanage_cmd(&self) -> assert_cmd::Command {
+        let mut cmd = self.gherrit_cmd();
         cmd.arg("unmanage");
         cmd
     }
 
     pub fn gherrit_id(&self, ref_name: &str) -> Result<String, Box<dyn std::error::Error>> {
-        let assert = self.git().args(["log", "-1", "--format=%B", ref_name]).assert().success();
+        let assert = self.git_cmd().args(["log", "-1", "--format=%B", ref_name]).assert().success();
         let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
 
         stdout
@@ -538,12 +573,14 @@ impl TestContext {
         &self,
         mut cmd: impl IntoCommandRef,
         redactions: &[(&str, &str)],
+        expected_exit: ExpectedExit,
     ) -> String {
         let cmd = cmd.as_command_mut();
         let output = cmd.output().expect("Failed to execute command");
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let succeeded = output.status.success();
         let exit_code = output.status.code().unwrap_or(-1);
 
         // This output will be stored verbatim in the filesystem.
@@ -553,8 +590,23 @@ impl TestContext {
             if stdout.is_empty() { "(empty)" } else { &stdout },
             if stderr.is_empty() { "(empty)" } else { &stderr }
         );
-        self.sanitize_with_redactions(&output, redactions)
+        let output = self.sanitize_with_redactions(&output, redactions);
+        match expected_exit {
+            ExpectedExit::Success => {
+                assert!(succeeded, "Expected command to succeed:\n{output}");
+            }
+            ExpectedExit::Failure => {
+                assert!(!succeeded, "Expected command to fail:\n{output}");
+            }
+        }
+        output
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpectedExit {
+    Success,
+    Failure,
 }
 
 fn redact_identities(output: &str, regex: &Regex, namespace: &str) -> String {
@@ -616,12 +668,23 @@ mod tests {
 }
 
 #[macro_export]
-macro_rules! assert_snapshot {
+macro_rules! assert_success_snapshot {
     ($ctx:expr, $cmd:expr, $name:expr $(,)?) => {
-        $crate::assert_snapshot!($ctx, $cmd, $name, &[])
+        $crate::assert_success_snapshot!($ctx, $cmd, $name, &[])
     };
     ($ctx:expr, $cmd:expr, $name:expr, $redactions:expr $(,)?) => {
-        let content = $ctx.execute_and_format($cmd, $redactions);
+        let content = $ctx.execute_and_format($cmd, $redactions, $crate::ExpectedExit::Success);
+        insta::assert_snapshot!($name, content);
+    };
+}
+
+#[macro_export]
+macro_rules! assert_failure_snapshot {
+    ($ctx:expr, $cmd:expr, $name:expr $(,)?) => {
+        $crate::assert_failure_snapshot!($ctx, $cmd, $name, &[])
+    };
+    ($ctx:expr, $cmd:expr, $name:expr, $redactions:expr $(,)?) => {
+        let content = $ctx.execute_and_format($cmd, $redactions, $crate::ExpectedExit::Failure);
         insta::assert_snapshot!($name, content);
     };
 }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Lazy command factories looked like eager actions, while failure tests
often accepted any nonzero exit status. Snapshot tests also encoded
their expected status only inside updateable output.

Mark builders as must-use, name them explicitly, require snapshot
callers to declare success or failure, and assert injected diagnostics
and side effects.




---

- 　  #308
- 　  #307
- 　  #306
- 　  #305
- 　  #303
- 　  #302
- 　  #301
- 👉 #300


**Latest Update:** v9 — [Compare vs v8](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v9|[v8](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|[v7](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|[v6](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|[v5](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|[v4](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|[v3](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|[v2](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|[v1](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v9)|
|v8||[v7](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8)|[v6](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8)|[v5](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8)|[v4](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8)|[v3](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8)|[v2](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8)|[v1](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8)|[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v8)|
|v7|||[v6](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7)|[v5](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7)|[v4](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7)|[v3](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7)|[v2](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7)|[v1](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7)|[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v7)|
|v6||||[v5](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6)|[v4](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6)|[v3](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6)|[v2](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6)|[v1](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6)|[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v6)|
|v5|||||[v4](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5)|[v3](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5)|[v2](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5)|[v1](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5)|[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v5)|
|v4||||||[v3](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4)|[v2](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4)|[v1](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4)|[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v4)|
|v3|||||||[v2](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3)|[v1](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3)|[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v3)|
|v2||||||||[v1](/joshlf/gherrit/compare/gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2)|[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v2)|
|v1|||||||||[Base](/joshlf/gherrit/compare/main..gherrit/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj && git checkout -b pr-Gajyki3v3kqjcl62fboxelcsh5kz3c5xj FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gajyki3v3kqjcl62fboxelcsh5kz3c5xj
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gajyki3v3kqjcl62fboxelcsh5kz3c5xj", "parent": null, "child": "Gvtyef4g2zcwptq3lflvoaxg66jyjqul2"}" -->