### PR TITLE
[tests] Make fixture capabilities explicit

### DIFF
--- a/tests/branch_config_transitions.rs
+++ b/tests/branch_config_transitions.rs
@@ -161,7 +161,7 @@ fn test_branch_config_transitions() {
         ]
     };
 
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
 
     for case in cases {
         println!("Running Case: {}", case.id);

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 #[test]
 fn test_commit_msg_hook() {
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
     let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");
     std::fs::write(&msg_file, "feat: my cool feature").unwrap();
 
@@ -21,7 +21,13 @@ fn test_commit_msg_hook() {
 
 #[test]
 fn test_full_stack_lifecycle_mocked() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .with_git_interceptor()
+        .build();
 
     // Setup: Create 'main' and a feature branch
     ctx.checkout_new("feature-stack");
@@ -42,7 +48,7 @@ fn test_full_stack_lifecycle_mocked() {
     // Verify Side Effects (Mock Only)
     testutil::assert_pr_snapshot!(ctx, "full_stack_lifecycle_state");
 
-    ctx.maybe_inspect_mock_state(|state| {
+    ctx.inspect_mock_state(|state| {
         assert!(state.pushes.iter().any(|push| push.succeeded()), "Expected a successful push");
     });
     assert!(!ctx.remote_refs("refs/heads").is_empty(), "Expected remote branches to be updated");
@@ -50,7 +56,7 @@ fn test_full_stack_lifecycle_mocked() {
 
 #[test]
 fn test_branch_management() {
-    let ctx = testutil::test_context_minimal!().install_hooks(true).build();
+    let ctx = testutil::test_context!().build();
 
     // Create a branch to manage
     ctx.checkout_new("feature-A");
@@ -95,7 +101,11 @@ fn test_branch_management() {
 
 #[test]
 fn test_post_checkout_hook() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .build();
 
     // Scenario A: New Feature Branch
 
@@ -122,7 +132,7 @@ fn test_post_checkout_hook() {
 
 #[test]
 fn test_commit_msg_edge_cases() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!().with_initial_commit().build();
     // Ensure we are managed so the hook is active
     testutil::assert_success_snapshot!(ctx, ctx.manage_cmd(), "commit_msg_edge_manage");
 
@@ -158,7 +168,7 @@ fn test_commit_msg_edge_cases() {
 
 #[test]
 fn test_pre_push_ancestry_check() {
-    let ctx = testutil::test_context_minimal!().install_hooks(true).build();
+    let ctx = testutil::test_context!().with_installed_hooks().build();
 
     // Setup: Create a normal history first (common init)
     ctx.commit("Initial Root");
@@ -174,7 +184,13 @@ fn test_pre_push_ancestry_check() {
 
 #[test]
 fn test_version_increment() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .with_git_interceptor()
+        .build();
 
     // Create feature branch
     ctx.checkout_new("feat-versioning");
@@ -201,17 +217,21 @@ fn test_version_increment() {
     let v1_count_final = ctx.count_successfully_pushed_containing("/v1");
     assert_eq!(v1_count_final, v1_count, "v1 tag should NOT be pushed again in the second push.");
 
-    if !ctx.is_live {
-        // Verify that tags actually exist on the remote
-        let tags = ctx.remote_refs("refs/tags/gherrit");
-        assert!(tags.iter().any(|tag| tag.ends_with("/v1")), "Remote should contain v1 tag");
-        assert!(tags.iter().any(|tag| tag.ends_with("/v2")), "Remote should contain v2 tag");
-    }
+    // Verify that tags actually exist on the remote.
+    let tags = ctx.remote_refs("refs/tags/gherrit");
+    assert!(tags.iter().any(|tag| tag.ends_with("/v1")), "Remote should contain v1 tag");
+    assert!(tags.iter().any(|tag| tag.ends_with("/v2")), "Remote should contain v2 tag");
 }
 
 #[test]
 fn test_optimistic_locking_conflict() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .with_git_interceptor()
+        .build();
 
     // Initial setup
     ctx.checkout_new("feature-conflict");
@@ -245,7 +265,7 @@ fn test_optimistic_locking_conflict() {
     // Attempt push - should fail due to atomic lock
     testutil::assert_failure_snapshot!(ctx, ctx.hook_cmd("pre-push"), "optimistic_locking_v2_fail");
 
-    ctx.maybe_inspect_mock_state(|state| {
+    ctx.inspect_mock_state(|state| {
         assert_eq!(state.pushes.len(), 2, "Expected one successful and one failed push");
         assert!(state.pushes[0].succeeded(), "Initial push should succeed");
         assert!(!state.pushes[1].succeeded(), "Conflicting push should fail");
@@ -259,7 +279,12 @@ fn test_optimistic_locking_conflict() {
 
 #[test]
 fn test_pr_body_generation() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
 
     // Setup: Stack of 3 commits: A -> B -> C
     // Must be on a feature branch (not main) for gherrit to sync them
@@ -291,7 +316,13 @@ fn test_pr_body_generation() {
 
 #[test]
 fn test_large_stack_batching() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .with_git_interceptor()
+        .build();
 
     // Create feature branch
     ctx.checkout_new("large-stack");
@@ -305,7 +336,7 @@ fn test_large_stack_batching() {
     // Using simple pre-push hook invocation.
     testutil::assert_success_snapshot!(ctx, ctx.hook_cmd("pre-push"), "large_stack_batching");
 
-    ctx.maybe_inspect_mock_state(|state| {
+    ctx.inspect_mock_state(|state| {
         // Assert: Push was split into 2 batches (80 + 5)
         assert_eq!(
             state.pushes.iter().filter(|push| push.succeeded()).count(),
@@ -327,7 +358,7 @@ fn test_large_stack_batching() {
 
 #[test]
 fn test_rebase_detection() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!().with_installed_hooks().with_initial_commit().build();
 
     ctx.checkout_new("feature-rebase");
     ctx.commit("Feature Work");
@@ -349,7 +380,8 @@ fn test_rebase_detection() {
 
 #[test]
 fn test_public_stack_links() {
-    let ctx = testutil::test_context_minimal!().install_hooks(true).build();
+    let ctx =
+        testutil::test_context!().with_remote().with_installed_hooks().with_mock_github().build();
 
     ctx.commit("Init");
     // 1. Private Mode (Default)
@@ -373,7 +405,7 @@ fn test_public_stack_links() {
 
 #[test]
 fn test_install_command_edge_cases() {
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
 
     let hooks_dir = ctx.repo_path.join(".git/hooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
@@ -425,7 +457,11 @@ fn test_install_command_edge_cases() {
 
 #[test]
 fn test_installed_pre_push_hook_accepts_git_arguments() {
-    let ctx = testutil::test_context_minimal!().install_hooks(true).initial_commit(true).build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .build();
 
     // Git invokes the pre-push hook with the remote name and location.
     ctx.git_cmd().args(["push", "origin", "main"]).assert().success();
@@ -433,7 +469,7 @@ fn test_installed_pre_push_hook_accepts_git_arguments() {
 
 #[test]
 fn test_install_configuration_and_security() {
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
 
     // Scenario A: Automatic Directory Creation (Default Path)
     // -------------------------------------------------------
@@ -499,8 +535,7 @@ fn test_install_configuration_and_security() {
 
 #[test]
 fn test_manage_detached_head() {
-    let ctx = testutil::test_context_minimal!().build();
-    ctx.commit("Init");
+    let ctx = testutil::test_context!().with_initial_commit().build();
 
     // Enter detached HEAD state
     ctx.run_git(&["checkout", "--detach"]);
@@ -517,8 +552,7 @@ fn test_manage_detached_head() {
 
 #[test]
 fn test_unmanage_cleanup_logic() {
-    let ctx = testutil::test_context_minimal!().build();
-    ctx.commit("Init");
+    let ctx = testutil::test_context!().with_initial_commit().build();
     ctx.checkout_new("feature-cleanup");
 
     // Manually configure the state to exact values that trigger the deep cleanup logic
@@ -539,7 +573,7 @@ fn test_unmanage_cleanup_logic() {
 
 #[test]
 fn test_pre_push_failure() {
-    let ctx = testutil::test_context_minimal!().install_hooks(true).build();
+    let ctx = testutil::test_context!().with_installed_hooks().with_mock_github().build();
     ctx.commit("Init");
 
     ctx.checkout_new("feature-fail");
@@ -567,7 +601,7 @@ fn test_install_read_only_fs() {
         return;
     }
 
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
     let hooks_dir = ctx.repo_path.join(".git/hooks");
     std::fs::create_dir_all(&hooks_dir).unwrap();
 
@@ -591,7 +625,7 @@ fn test_install_read_only_fs() {
 
 #[test]
 fn test_manage_drift_detection() {
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
     ctx.checkout_new("drift-feature");
 
     // 1. Initialize managed private branch
@@ -631,7 +665,7 @@ fn test_manage_drift_detection() {
 
 #[test]
 fn test_manage_toggle_visibility() {
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
     ctx.checkout_new("visibility-feature");
 
     // 1. Private
@@ -661,7 +695,7 @@ fn test_manage_toggle_visibility() {
 
 #[test]
 fn test_manage_mutually_exclusive_flags() {
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
     ctx.checkout_new("conflict-feature");
 
     // Attempt to set both flags
@@ -674,7 +708,7 @@ fn test_manage_mutually_exclusive_flags() {
 
 #[test]
 fn test_manage_invalid_config() {
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().build();
     ctx.checkout_new("invalid-config-feature");
 
     // Manually set invalid config
@@ -686,7 +720,11 @@ fn test_manage_invalid_config() {
 
 #[test]
 fn test_post_checkout_drift_detection() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .build();
 
     // Condition A: Shared Branch Drift (Unmanaged vs Upstream Config)
     ctx.run_git(&["checkout", "main"]);

--- a/tests/migration_edge_cases.rs
+++ b/tests/migration_edge_cases.rs
@@ -1,6 +1,11 @@
 #[test]
 fn test_mixed_stack_backward_compatibility() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
 
     // Checking out a new branch enables management through the installed hook.
     ctx.checkout_new("mixed-stack");
@@ -29,7 +34,7 @@ fn test_mixed_stack_backward_compatibility() {
 
 #[test]
 fn test_base32_format_compliance() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!().with_installed_hooks().with_initial_commit().build();
     ctx.checkout_new("base32-format");
     ctx.commit("Base32 Commit");
 

--- a/tests/pre_push_autosquash.rs
+++ b/tests/pre_push_autosquash.rs
@@ -24,7 +24,11 @@ fn test_autosquash_prefixes() {
     // ensures that even if a user creates these commits manually or via other
     // tools, GHerrit will catch them before they reach the remote.
 
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .build();
 
     let prefixes = ["fixup!", "squash!", "amend!"];
     for prefix in prefixes {
@@ -55,7 +59,11 @@ fn test_buried_autosquash_commit() {
     //
     // Even though HEAD (Commit C) is clean, the push includes Commit B, so it
     // must fail.
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .build();
     ctx.checkout_new("feature-buried");
 
     // 1. Commit A
@@ -81,7 +89,11 @@ fn test_precedence_over_trailer_check() {
     // definition temporary/incomplete, so it doesn't matter if it has a valid
     // ID or not.
 
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .build();
     ctx.checkout_new("feature-precedence");
 
     // Create a fixup commit that ALSO has a valid trailer. Normally, a trailer
@@ -108,7 +120,7 @@ fn test_dynamic_remote_and_branch_suggestion() {
     //
     //   git rebase -i --autosquash upstream/master
 
-    let ctx = testutil::test_context_minimal!().build();
+    let ctx = testutil::test_context!().with_installed_hooks().build();
 
     // Configure default branch to be 'master' to test dynamic branch name
     // detection.
@@ -135,8 +147,6 @@ fn test_dynamic_remote_and_branch_suggestion() {
     ctx.run_git(&["config", "gherrit.remote", "upstream"]);
 
     // Install hooks manually since we didn't use init_and_install_hooks
-    ctx.install_hooks();
-
     ctx.commit("Initial commit");
     ctx.checkout_new("feature-dynamic");
 
@@ -152,7 +162,12 @@ fn test_dynamic_remote_and_branch_suggestion() {
 fn test_valid_stack_passes() {
     // Control group test: standard, valid commits should pass without issues.
 
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
     ctx.checkout_new("feature-valid");
 
     // Stack of 3 normal commits

--- a/tests/prevent_push_to_closed_pr.rs
+++ b/tests/prevent_push_to_closed_pr.rs
@@ -1,7 +1,12 @@
 use predicates::prelude::*;
 
 fn verify_push_to_non_open_fail(state_arg: &str, expected_msg_part: &str) {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
     ctx.checkout_new(&format!("feature-{}", state_arg.to_lowercase()));
 
     // 1. Initial Push (Creates PR)
@@ -10,7 +15,7 @@ fn verify_push_to_non_open_fail(state_arg: &str, expected_msg_part: &str) {
     let refs_before_rejected_push = ctx.remote_refs("refs");
 
     // 2. Simulate PR State Change on GitHub
-    ctx.maybe_mutate_mock_state(|state| {
+    ctx.mutate_mock_state(|state| {
         let pr = state.prs.last_mut().unwrap();
         pr.state = state_arg.to_string();
     });
@@ -23,13 +28,6 @@ fn verify_push_to_non_open_fail(state_arg: &str, expected_msg_part: &str) {
     let name = format!("prevent_push_to_{}_pr_state", state_arg.to_lowercase());
     testutil::assert_pr_snapshot!(ctx, name.as_str());
 
-    ctx.maybe_inspect_mock_state(|state| {
-        assert_eq!(
-            state.pushes.iter().filter(|push| push.succeeded()).count(),
-            1,
-            "Should not have pushed to {state_arg} PR"
-        );
-    });
     assert_eq!(ctx.remote_refs("refs"), refs_before_rejected_push);
 }
 
@@ -45,7 +43,12 @@ fn test_post_push_checks_merged_pr() {
 
 #[test]
 fn test_push_to_open_pr_succeeds() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
     ctx.checkout_new("feature-open");
     ctx.commit("Work");
 

--- a/tests/regression_batch_update_failure.rs
+++ b/tests/regression_batch_update_failure.rs
@@ -2,7 +2,12 @@ use predicates::prelude::*;
 
 #[test]
 fn test_regression_batch_update_silent_failure() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
     ctx.checkout_new("feature-update-fail");
 
     // 1. Initial Push (creates PR)

--- a/tests/reproduce_issue.rs
+++ b/tests/reproduce_issue.rs
@@ -18,7 +18,13 @@ fn test_special_characters_in_repo_url() {
 
     for (user, repo) in scenarios {
         println!("Testing scenario: {user}/{repo}");
-        let ctx = testutil::test_context!().owner(user).name(repo).build();
+        let ctx = testutil::test_context!()
+            .repository(user, repo)
+            .with_remote()
+            .with_installed_hooks()
+            .with_initial_commit()
+            .with_mock_github()
+            .build();
 
         ctx.checkout_new("feature-stack");
 

--- a/tests/reproduce_merge_queue_failure.rs
+++ b/tests/reproduce_merge_queue_failure.rs
@@ -5,7 +5,12 @@ fn test_reproduce_merge_queue_failure() {
     // the mock server, simulating a merge queue environment. 'gherrit' should
     // avoid updating the base branch if it hasn't changed, preventing failure.
 
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
 
     // 1. Create a PR
     ctx.checkout_new("feature-branch");
@@ -14,12 +19,12 @@ fn test_reproduce_merge_queue_failure() {
 
     // Get the PR ID
     let mut pr_id = 0;
-    ctx.maybe_inspect_mock_state(|state| {
+    ctx.inspect_mock_state(|state| {
         pr_id = state.prs[0].id;
     });
 
     // 2. Add the PR to the merge queue
-    ctx.maybe_mutate_mock_state(move |state| {
+    ctx.mutate_mock_state(move |state| {
         state.merge_queue.insert(pr_id);
     });
 

--- a/tests/reproduce_pagination_bug.rs
+++ b/tests/reproduce_pagination_bug.rs
@@ -1,6 +1,7 @@
 #[test]
 fn test_pagination_bug() {
-    let ctx = testutil::test_context!().build();
+    let ctx =
+        testutil::test_context!().with_remote().with_installed_hooks().with_mock_github().build();
 
     // 1. Setup base commit on main
     ctx.commit("Init");
@@ -15,7 +16,7 @@ fn test_pagination_bug() {
     ctx.commit(&msg);
 
     // 4. Generate 110 PRs in the mock server state
-    ctx.maybe_mutate_mock_state(|state| {
+    ctx.mutate_mock_state(|state| {
         for i in 1..=110 {
             let is_target = i == 105;
             let head_ref =

--- a/tests/reproduce_pr_base_bug.rs
+++ b/tests/reproduce_pr_base_bug.rs
@@ -4,7 +4,12 @@ fn test_reproduce_pr_base_branch_bug() {
     // are always created with the repository's default branch (e.g., "main") as
     // the base, rather than using the local feature branch name.
 
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
 
     ctx.checkout_new("feature-branch");
     ctx.commit("Feature Work");

--- a/tests/reproduce_status_bugs.rs
+++ b/tests/reproduce_status_bugs.rs
@@ -3,7 +3,7 @@
 fn test_commit_msg_trailer_failure() {
     use std::os::unix::fs::PermissionsExt;
 
-    let ctx = testutil::test_context_minimal!().install_hooks(true).build();
+    let ctx = testutil::test_context!().build();
 
     // Manage branch to enable hook
     ctx.gherrit_cmd().args(["manage"]).assert().success();
@@ -27,7 +27,12 @@ fn test_commit_msg_trailer_failure() {
 
 #[test]
 fn test_pre_push_edit_failure() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .build();
 
     // Setup: Create PR first
     ctx.checkout_new("feature-edit-fail");
@@ -47,7 +52,7 @@ fn test_pre_push_edit_failure() {
         .failure()
         .stderr(predicates::str::contains("Injected UpdatePr failure"));
     ctx.assert_failure_consumed();
-    ctx.maybe_inspect_mock_state(|state| {
+    ctx.inspect_mock_state(|state| {
         assert_eq!(
             state.graphql_requests.last(),
             Some(&vec![testutil::mock_server::GraphQlOperation::UpdatePr])

--- a/tests/reproduce_unchecked_output_bugs.rs
+++ b/tests/reproduce_unchecked_output_bugs.rs
@@ -2,7 +2,13 @@ use predicates::prelude::*;
 
 #[test]
 fn test_pre_push_ls_remote_failure() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .with_git_interceptor()
+        .build();
     // Manage branch
     ctx.checkout_new("feature-ls-remote-fail");
     ctx.commit("Work");
@@ -18,7 +24,13 @@ fn test_pre_push_ls_remote_failure() {
 
 #[test]
 fn test_pre_push_pr_list_failure() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .with_git_interceptor()
+        .build();
     ctx.checkout_new("feature-pr-list-fail");
     ctx.commit("Work");
 
@@ -31,7 +43,7 @@ fn test_pre_push_pr_list_failure() {
         .failure()
         .stderr(predicate::str::contains("Injected GraphQl failure"));
     ctx.assert_failure_consumed();
-    ctx.maybe_inspect_mock_state(|state| {
+    ctx.inspect_mock_state(|state| {
         assert_eq!(
             state.graphql_requests,
             vec![vec![testutil::mock_server::GraphQlOperation::Query]]
@@ -43,7 +55,13 @@ fn test_pre_push_pr_list_failure() {
 
 #[test]
 fn test_pre_push_pr_create_failure() {
-    let ctx = testutil::test_context!().build();
+    let ctx = testutil::test_context!()
+        .with_remote()
+        .with_installed_hooks()
+        .with_initial_commit()
+        .with_mock_github()
+        .with_git_interceptor()
+        .build();
     ctx.checkout_new("feature-pr-create-fail");
     ctx.commit("Work");
 
@@ -56,7 +74,7 @@ fn test_pre_push_pr_create_failure() {
         .failure()
         .stderr(predicate::str::contains("Injected CreatePr failure"));
     ctx.assert_failure_consumed();
-    ctx.maybe_inspect_mock_state(|state| {
+    ctx.inspect_mock_state(|state| {
         assert_eq!(
             state.graphql_requests.last(),
             Some(&vec![testutil::mock_server::GraphQlOperation::CreatePr])
@@ -70,7 +88,7 @@ fn test_pre_push_pr_create_failure() {
 fn test_commit_msg_git_var_failure() {
     #[cfg(unix)]
     {
-        let ctx = testutil::test_context_minimal!().install_hooks(true).build();
+        let ctx = testutil::test_context!().with_git_interceptor().build();
         ctx.gherrit_cmd().args(["manage"]).assert().success();
 
         let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");
@@ -89,7 +107,7 @@ fn test_commit_msg_git_var_failure() {
 fn test_commit_msg_trailers_failure() {
     #[cfg(unix)]
     {
-        let ctx = testutil::test_context_minimal!().install_hooks(true).build();
+        let ctx = testutil::test_context!().with_git_interceptor().build();
         ctx.gherrit_cmd().args(["manage"]).assert().success();
 
         let msg_file = ctx.repo_path.join("COMMIT_EDITMSG");

--- a/tests/reproduce_unmanaged_sync.rs
+++ b/tests/reproduce_unmanaged_sync.rs
@@ -1,4 +1,4 @@
-use testutil::test_context_minimal;
+use testutil::test_context;
 
 #[test]
 fn test_reproduce_unmanaged_sync() {
@@ -7,7 +7,7 @@ fn test_reproduce_unmanaged_sync() {
     // and `gherritManaged = unmanaged`. We also spuriously synced
     // unmanaged branches. This is a regression test for the latter bug.
 
-    let ctx = test_context_minimal!().install_hooks(true).build();
+    let ctx = test_context!().with_installed_hooks().build();
 
     // Condition 1: Explicit Unmanaged
     ctx.checkout_new("explicit-unmanaged");
@@ -20,8 +20,6 @@ fn test_reproduce_unmanaged_sync() {
         "reproduce_unmanaged_sync_explicit"
     );
 
-    testutil::assert_pr_snapshot!(ctx, "reproduce_unmanaged_sync_explicit_state");
-
     // Condition 2: Implicit Unmanaged
     ctx.checkout_new("implicit-unmanaged");
     ctx.set_config("branch.implicit-unmanaged.gherritManaged", None);
@@ -32,6 +30,4 @@ fn test_reproduce_unmanaged_sync() {
         ctx.hook_cmd("pre-push"),
         "reproduce_unmanaged_sync_implicit"
     );
-
-    testutil::assert_pr_snapshot!(ctx, "reproduce_unmanaged_sync_implicit_state");
 }

--- a/tests/snapshots/reproduce_unmanaged_sync__reproduce_unmanaged_sync_explicit_state.snap
+++ b/tests/snapshots/reproduce_unmanaged_sync__reproduce_unmanaged_sync_explicit_state.snap
@@ -1,5 +1,0 @@
----
-source: tests/reproduce_unmanaged_sync.rs
-expression: ctx.formatted_mock_pr_state()
----
-[]

--- a/tests/snapshots/reproduce_unmanaged_sync__reproduce_unmanaged_sync_implicit_state.snap
+++ b/tests/snapshots/reproduce_unmanaged_sync__reproduce_unmanaged_sync_implicit_state.snap
@@ -1,5 +1,0 @@
----
-source: tests/reproduce_unmanaged_sync.rs
-expression: ctx.formatted_mock_pr_state()
----
-[]

--- a/tests/verify_repo_args.rs
+++ b/tests/verify_repo_args.rs
@@ -3,13 +3,14 @@ use testutil::test_context;
 
 #[test]
 fn test_repository_query_arguments() {
-    let ctx = test_context!().build();
-    let url = &ctx.mock_server.as_ref().expect("Mock server not started").url;
-    let graphql_url = format!("{}/graphql", url);
+    let ctx = test_context!().with_mock_github().build();
+    let graphql_url = format!("{}/graphql", ctx.mock_server_url());
 
-    let state = ctx.read_mock_state();
-    let owner = state.repo_owner;
-    let name = state.repo_name;
+    let mut repository = None;
+    ctx.inspect_mock_state(|state| {
+        repository = Some((state.repo_owner.clone(), state.repo_name.clone()));
+    });
+    let (owner, name) = repository.unwrap();
 
     // Query with correct arguments (should succeed)
     let query = format!("query {{ repository(owner: \"{owner}\", name: \"{name}\") {{ id }} }}");

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -26,16 +26,7 @@ const FIRST_GIT_TIMESTAMP: u64 = 946_684_800;
 #[macro_export]
 macro_rules! test_context {
     () => {
-        $crate::TestContextBuilder::new()
-            .binaries(assert_cmd::cargo::cargo_bin!("gherrit"), $crate::build_mock_bin())
-    };
-}
-
-#[macro_export]
-macro_rules! test_context_minimal {
-    () => {
-        $crate::TestContextBuilder::new_minimal()
-            .binaries(assert_cmd::cargo::cargo_bin!("gherrit"), $crate::build_mock_bin())
+        $crate::TestContextBuilder::new(assert_cmd::cargo::cargo_bin!("gherrit"))
     };
 }
 
@@ -67,63 +58,66 @@ pub fn build_mock_bin() -> PathBuf {
 pub struct TestContextBuilder {
     owner: String,
     name: String,
-    install_hooks: bool,
+    remote: bool,
+    installed_hooks: bool,
     initial_commit: bool,
-    gherrit_bin: Option<PathBuf>,
-    mock_bin: Option<PathBuf>,
-}
-
-impl Default for TestContextBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
+    mock_github: bool,
+    git_interceptor: bool,
+    gherrit_bin: PathBuf,
 }
 
 impl TestContextBuilder {
-    pub fn new() -> Self {
-        let mut slf = Self::new_minimal();
-        slf.install_hooks(true).initial_commit(true);
-        slf
-    }
-
-    pub fn new_minimal() -> Self {
+    pub fn new(gherrit_bin: impl Into<PathBuf>) -> Self {
         Self {
             owner: DEFAULT_OWNER.to_string(),
             name: DEFAULT_REPO.to_string(),
-            install_hooks: false,
+            remote: false,
+            installed_hooks: false,
             initial_commit: false,
-            gherrit_bin: None,
-            mock_bin: None,
+            mock_github: false,
+            git_interceptor: false,
+            gherrit_bin: gherrit_bin.into(),
         }
     }
 
-    pub fn binaries(&mut self, gherrit: impl Into<PathBuf>, mock: impl Into<PathBuf>) -> &mut Self {
-        self.gherrit_bin = Some(gherrit.into());
-        self.mock_bin = Some(mock.into());
-        self
-    }
-
-    pub fn owner(&mut self, owner: &str) -> &mut Self {
+    #[must_use]
+    pub fn repository(mut self, owner: &str, name: &str) -> Self {
         self.owner = owner.to_string();
-        self
-    }
-
-    pub fn name(&mut self, name: &str) -> &mut Self {
         self.name = name.to_string();
         self
     }
 
-    pub fn install_hooks(&mut self, install_hooks: bool) -> &mut Self {
-        self.install_hooks = install_hooks;
+    #[must_use]
+    pub fn with_remote(mut self) -> Self {
+        self.remote = true;
         self
     }
 
-    pub fn initial_commit(&mut self, initial_commit: bool) -> &mut Self {
-        self.initial_commit = initial_commit;
+    #[must_use]
+    pub fn with_installed_hooks(mut self) -> Self {
+        self.installed_hooks = true;
         self
     }
 
-    pub fn build(&self) -> TestContext {
+    #[must_use]
+    pub fn with_initial_commit(mut self) -> Self {
+        self.initial_commit = true;
+        self
+    }
+
+    #[must_use]
+    pub fn with_mock_github(mut self) -> Self {
+        self.mock_github = true;
+        self
+    }
+
+    #[must_use]
+    pub fn with_git_interceptor(mut self) -> Self {
+        self.git_interceptor = true;
+        self
+    }
+
+    pub fn build(self) -> TestContext {
         if std::env::var("GHERRIT_TEST_BUILD").is_err() {
             eprintln!("\n\x1b[31mERROR: You must run these tests with GHERRIT_TEST_BUILD=1\x1b[0m");
             eprintln!("This ensures the binary is compiled with the necessary test hooks.\n");
@@ -137,25 +131,30 @@ impl TestContextBuilder {
         fs::create_dir(&repo_path).unwrap();
 
         let remote_parent = dir.path().join(&self.owner);
-        fs::create_dir_all(&remote_parent).unwrap();
         let remote_path = remote_parent.join(format!("{}.git", self.name));
-        init_git_bare_repo(&test_environment, &system_git, &remote_path);
+        if self.remote {
+            fs::create_dir_all(&remote_parent).unwrap();
+            init_git_bare_repo(&test_environment, &system_git, &remote_path);
+        }
 
-        let is_live = env::var("GHERRIT_LIVE_TEST").is_ok();
-        let live_github_token = is_live.then(resolve_live_github_token);
+        init_git_repo(
+            &test_environment,
+            &system_git,
+            &repo_path,
+            self.remote.then_some(remote_path.as_path()),
+        );
 
-        init_git_repo(&test_environment, &system_git, &repo_path, &remote_path);
-
-        let gherrit_bin = self.gherrit_bin.clone().expect("gherrit binary path must be set");
-        let mock_bin = self.mock_bin.clone().expect("mock binary path must be set");
+        if self.installed_hooks {
+            install_gherrit_binary(dir.path(), &self.gherrit_bin);
+        }
+        if self.git_interceptor {
+            install_git_interceptor(dir.path(), &build_mock_bin());
+        }
 
         let mut mock_server_state = None;
 
-        let mock_server = (!is_live).then(|| {
-            install_mock_binaries(dir.path(), &mock_bin, &gherrit_bin);
-
+        let mock_server = (self.mock_github || self.git_interceptor).then(|| {
             let state = mock_server::MockState::new(self.owner.clone(), self.name.clone());
-
             let state = Arc::new(RwLock::new(state));
             mock_server_state = Some(state.clone());
 
@@ -186,19 +185,20 @@ impl TestContextBuilder {
         let ctx = TestContext {
             dir,
             repo_path,
-            remote_path: remote_path.clone(),
-            is_live,
-            live_github_token,
+            remote_path,
+            has_remote: self.remote,
+            has_mock_github: self.mock_github,
+            has_git_interceptor: self.git_interceptor,
             system_git: system_git.clone(),
-            gherrit_bin_path: gherrit_bin.clone(),
+            gherrit_bin_path: self.gherrit_bin,
             test_environment,
             next_git_timestamp: AtomicU64::new(FIRST_GIT_TIMESTAMP),
             mock_server,
             mock_server_state,
         };
 
-        if self.install_hooks {
-            ctx.install_hooks();
+        if self.installed_hooks {
+            ctx.gherrit_cmd().arg("install").assert().success();
         }
 
         if self.initial_commit {
@@ -212,15 +212,16 @@ impl TestContextBuilder {
 pub struct TestContext {
     pub dir: TempDir,
     pub repo_path: PathBuf,
-    pub remote_path: PathBuf,
-    pub is_live: bool,
-    live_github_token: Option<String>,
     pub system_git: PathBuf,
     pub gherrit_bin_path: PathBuf,
+    remote_path: PathBuf,
+    has_remote: bool,
+    has_mock_github: bool,
+    has_git_interceptor: bool,
     test_environment: TestEnvironment,
     next_git_timestamp: AtomicU64,
-    pub mock_server: Option<MockServerInfo>,
-    pub mock_server_state: Option<Arc<RwLock<mock_server::MockState>>>,
+    mock_server: Option<MockServerInfo>,
+    mock_server_state: Option<Arc<RwLock<mock_server::MockState>>>,
 }
 
 #[derive(Clone)]
@@ -349,42 +350,6 @@ fn push_unique_path(paths: &mut Vec<PathBuf>, path: &Path) {
     }
 }
 
-fn resolve_live_github_token() -> String {
-    let mut gh_auth_token = Command::new("gh");
-    gh_auth_token.args(["auth", "token"]);
-    resolve_live_github_token_with(env::var_os("GITHUB_TOKEN"), &mut gh_auth_token)
-        .unwrap_or_else(|message| panic!("Live GitHub authentication failed: {message}"))
-}
-
-fn resolve_live_github_token_with(
-    github_token: Option<OsString>,
-    gh_auth_token: &mut Command,
-) -> Result<String, String> {
-    if let Some(token) = github_token.and_then(|token| token.into_string().ok()) {
-        if !token.is_empty() {
-            return Ok(token);
-        }
-    }
-
-    let output = gh_auth_token
-        .output()
-        .map_err(|error| format!("failed to run `gh auth token`: {error}"))?;
-    if !output.status.success() {
-        return Err(
-            "`gh auth token` did not return a token; set GITHUB_TOKEN or run `gh auth login`"
-                .to_string(),
-        );
-    }
-
-    let token = String::from_utf8(output.stdout)
-        .map_err(|_| "`gh auth token` returned non-UTF-8 output".to_string())?;
-    let token = token.trim().to_string();
-    if token.is_empty() {
-        return Err("`gh auth token` returned an empty token".to_string());
-    }
-    Ok(token)
-}
-
 pub struct MockServerInfo {
     pub url: String,
     pub shutdown_tx: tokio::sync::oneshot::Sender<()>,
@@ -417,17 +382,20 @@ impl TestContext {
         cmd.env("GIT_AUTHOR_DATE", &git_date);
         cmd.env("GIT_COMMITTER_DATE", &git_date);
 
-        if !self.is_live {
+        if self.has_git_interceptor {
             cmd.env("SYSTEM_GIT_PATH", &self.system_git);
 
             if let Some(server) = &self.mock_server {
                 cmd.env("GHERRIT_MOCK_SERVER_URL", &server.url);
             }
-        } else {
-            cmd.env(
-                "GITHUB_TOKEN",
-                self.live_github_token.as_ref().expect("live GitHub token was not resolved"),
-            );
+        }
+
+        // These variables belong on the outer Git command too: installed
+        // hooks inherit its environment when Git invokes GHerrit.
+        if self.has_mock_github {
+            let server = self.mock_server.as_ref().expect("mock GitHub server not available");
+            cmd.env("GHERRIT_GITHUB_API_URL", &server.url);
+            cmd.env("GITHUB_TOKEN", "mock-token");
         }
     }
 
@@ -439,18 +407,12 @@ impl TestContext {
 
         self.configure_test_env(&mut cmd);
 
-        if !self.is_live {
-            if let Some(server) = &self.mock_server {
-                cmd.env("GHERRIT_GITHUB_API_URL", &server.url);
-                cmd.env("GITHUB_TOKEN", "mock-token");
-            }
-        }
-
         cmd
     }
 
     #[must_use = "command builders do nothing until executed"]
     pub fn remote_git_cmd(&self) -> assert_cmd::Command {
+        assert!(self.has_remote, "missing test capability: .with_remote()");
         let mut cmd = assert_cmd::Command::new(&self.system_git);
         cmd.current_dir(&self.remote_path);
         self.configure_test_env(&mut cmd);
@@ -469,13 +431,15 @@ impl TestContext {
         cmd
     }
 
-    pub fn read_mock_state(&self) -> mock_server::MockState {
-        self.mock_server_state.as_ref().expect("Mock state not available").read().unwrap().clone()
+    fn mock_state(&self) -> &Arc<RwLock<mock_server::MockState>> {
+        self.mock_server_state
+            .as_ref()
+            .expect("missing test capability: .with_mock_github() or .with_git_interceptor()")
     }
 
-    pub fn install_hooks(&self) {
-        // Use the new install command
-        self.gherrit_cmd().args(["install"]).assert().success();
+    pub fn mock_server_url(&self) -> &str {
+        assert!(self.has_mock_github, "missing test capability: .with_mock_github()");
+        &self.mock_server.as_ref().expect("mock GitHub server not available").url
     }
 
     pub fn commit(&self, msg: &str) {
@@ -532,14 +496,14 @@ impl TestContext {
     }
 
     pub fn inject_failure(&self, kind: FailureKind) {
-        let mut state =
-            self.mock_server_state.as_ref().expect("Mock state not available").write().unwrap();
+        assert!(self.has_mock_github, "missing test capability: .with_mock_github()");
+        let mut state = self.mock_state().write().unwrap();
 
         state.fail_next_request = Some(kind);
     }
 
     pub fn assert_failure_consumed(&self) {
-        self.maybe_inspect_mock_state(|state| {
+        self.inspect_mock_state(|state| {
             assert!(
                 state.fail_next_request.is_none(),
                 "Expected injected failure to be consumed, but {:?} remains",
@@ -548,24 +512,20 @@ impl TestContext {
         });
     }
 
-    pub fn maybe_inspect_mock_state(&self, f: impl FnOnce(&mock_server::MockState)) {
-        if !self.is_live {
-            let state = self.read_mock_state();
-            f(&state);
-        }
+    pub fn inspect_mock_state(&self, f: impl FnOnce(&mock_server::MockState)) {
+        let state = self.mock_state().read().unwrap();
+        f(&state);
     }
 
-    pub fn maybe_mutate_mock_state(&self, f: impl FnOnce(&mut mock_server::MockState)) {
-        if !self.is_live {
-            let mut state =
-                self.mock_server_state.as_ref().expect("Mock state not available").write().unwrap();
-            f(&mut state);
-        }
+    pub fn mutate_mock_state(&self, f: impl FnOnce(&mut mock_server::MockState)) {
+        let mut state = self.mock_state().write().unwrap();
+        f(&mut state);
     }
 
     pub fn formatted_mock_pr_state(&self) -> String {
+        assert!(self.has_mock_github, "missing test capability: .with_mock_github()");
         let mut content = String::new();
-        self.maybe_inspect_mock_state(|state| {
+        self.inspect_mock_state(|state| {
             let json = serde_json::to_string_pretty(&state.prs).expect("Failed to serialize PRs");
             content = self.sanitize(&json);
         });
@@ -603,8 +563,9 @@ impl TestContext {
     }
 
     pub fn count_successfully_pushed_containing(&self, substring: &str) -> usize {
+        assert!(self.has_git_interceptor, "missing test capability: .with_git_interceptor()");
         let mut count = 0;
-        self.maybe_inspect_mock_state(|state| {
+        self.inspect_mock_state(|state| {
             count = state
                 .pushes
                 .iter()
@@ -840,62 +801,6 @@ mod tests {
     }
 
     #[test]
-    fn live_github_token_prefers_environment() {
-        let mut unusable_fallback = Command::new("gherrit-command-that-must-not-run");
-
-        let token = resolve_live_github_token_with(
-            Some(OsString::from("environment-token")),
-            &mut unusable_fallback,
-        )
-        .unwrap();
-
-        assert_eq!(token, "environment-token");
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn live_github_token_falls_back_to_gh_login() {
-        let mut gh_auth_token = Command::new("sh");
-        gh_auth_token.args(["-c", "printf 'login-token\\n'"]);
-
-        let token = resolve_live_github_token_with(None, &mut gh_auth_token).unwrap();
-
-        assert_eq!(token, "login-token");
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn live_environment_injects_captured_token_without_restoring_home() {
-        let dir = TempDir::new().unwrap();
-        let repo_path = dir.path().join("local");
-        fs::create_dir(&repo_path).unwrap();
-        let isolated_home = dir.path().join("home");
-        let test_environment = TestEnvironment::new(dir.path(), SYSTEM_GIT.as_path());
-        let ctx = TestContext {
-            remote_path: dir.path().join("remote.git"),
-            dir,
-            repo_path,
-            is_live: true,
-            live_github_token: Some("captured-token".to_string()),
-            system_git: SYSTEM_GIT.clone(),
-            gherrit_bin_path: PathBuf::from("/usr/bin/env"),
-            test_environment,
-            next_git_timestamp: AtomicU64::new(FIRST_GIT_TIMESTAMP),
-            mock_server: None,
-            mock_server_state: None,
-        };
-
-        let assert = ctx.gherrit_cmd().assert().success();
-        let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
-
-        assert!(output.lines().any(|line| line == "GITHUB_TOKEN=captured-token"));
-        assert!(
-            output.lines().any(|line| line == format!("HOME={}", isolated_home.display())),
-            "live command did not retain the fixture-owned HOME: {output}"
-        );
-    }
-
-    #[test]
     #[cfg(unix)]
     fn test_environment_clears_inherited_values() {
         let root = TempDir::new().unwrap();
@@ -945,11 +850,13 @@ fn run_git_cmd(environment: &TestEnvironment, system_git: &Path, path: &Path, ar
     environment.command(system_git).current_dir(path).args(args).assert().success();
 }
 
-pub fn install_mock_binaries(path: &Path, mock_bin: &Path, gherrit_bin: &Path) {
+fn install_git_interceptor(path: &Path, mock_bin: &Path) {
     let git_dst = path.join(if cfg!(windows) { "git.exe" } else { "git" });
-    let gherrit_dst = path.join(if cfg!(windows) { "gherrit.exe" } else { "gherrit" });
-
     fs::copy(mock_bin, &git_dst).unwrap();
+}
+
+fn install_gherrit_binary(path: &Path, gherrit_bin: &Path) {
+    let gherrit_dst = path.join(if cfg!(windows) { "gherrit.exe" } else { "gherrit" });
     fs::copy(gherrit_bin, &gherrit_dst).unwrap();
 }
 
@@ -962,7 +869,7 @@ fn init_git_repo(
     environment: &TestEnvironment,
     system_git: &Path,
     path: &Path,
-    remote_path: &Path,
+    remote_path: Option<&Path>,
 ) {
     let run = |args| run_git_cmd(environment, system_git, path, args);
     run(&["init"]);
@@ -974,8 +881,9 @@ fn init_git_repo(
     run(&["symbolic-ref", "HEAD", "refs/heads/main"]);
     // Explicitly unmanage main to satisfy strict config checks
     run(&["config", "branch.main.gherritManaged", "false"]);
-    // Add origin remote
-    run(&["remote", "add", "origin", remote_path.to_str().unwrap()]);
+    if let Some(remote_path) = remote_path {
+        run(&["remote", "add", "origin", remote_path.to_str().unwrap()]);
+    }
 }
 
 static SYSTEM_GIT: LazyLock<PathBuf> = LazyLock::new(|| -> PathBuf {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The two context presets always created a remote, mock server, and Git
interceptor, even for tests that exercised only local behavior. Their
names hid the side effects each test relied on, and an environment
variable could silently disable assertions by selecting live mode.

Start with a local repository and let each test opt into its remote,
installed hooks, initial commit, mock GitHub, and Git interception.
Build the interceptor lazily, remove live-mode no-ops, and make helpers
fail clearly when their capability was not requested.




---

- 　  #308
- 　  #307
- 　  #306
- 　  #305
- 　  #303
- 👉 #302


**Latest Update:** v11 — [Compare vs v10](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v11|[v10](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v9](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v8](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v7](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v6](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v5](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v4](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v3](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v11)|
|v10||[v9](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[v8](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[v7](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[v6](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[v5](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[v4](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[v3](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v10)|
|v9|||[v8](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|[v7](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|[v6](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|[v5](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|[v4](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|[v3](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v9)|
|v8||||[v7](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8)|[v6](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8)|[v5](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8)|[v4](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8)|[v3](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8)|[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v8)|
|v7|||||[v6](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7)|[v5](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7)|[v4](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7)|[v3](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7)|[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v7)|
|v6||||||[v5](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6)|[v4](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6)|[v3](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6)|[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v6)|
|v5|||||||[v4](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5)|[v3](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5)|[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v5)|
|v4||||||||[v3](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4)|[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v4)|
|v3|||||||||[v2](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3)|[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v3)|
|v2||||||||||[v1](/joshlf/gherrit/compare/gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2)|[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v2)|
|v1|||||||||||[Base](/joshlf/gherrit/compare/main..gherrit/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs && git checkout -b pr-Gddsniwsq2ll7chfkz6v6qojo32g4gzxs FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gddsniwsq2ll7chfkz6v6qojo32g4gzxs
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gddsniwsq2ll7chfkz6v6qojo32g4gzxs", "parent": null, "child": "Gaz6bmxf56vt52yfldhvrymxpwnebxczb"}" -->