### PR TITLE
[tests] Bound harness lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "concolor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,6 +3863,7 @@ dependencies = [
  "apollo-compiler",
  "assert_cmd",
  "axum",
+ "command-group",
  "insta",
  "lazy_static",
  "predicates",

--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 assert_cmd = "2.1"
+command-group = "5.0.1"
 tempfile = "3.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/testutil/src/command.rs
+++ b/testutil/src/command.rs
@@ -1,0 +1,233 @@
+use std::{
+    ffi::OsStr,
+    io::{self, Read},
+    path::Path,
+    process::{Command, ExitStatus, Output, Stdio},
+    sync::mpsc::{self, Receiver, RecvTimeoutError},
+    thread,
+    time::{Duration, Instant},
+};
+
+use command_group::{CommandGroup, GroupChild};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+const CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Debug)]
+pub struct TestCommand {
+    command: Command,
+    timeout: Duration,
+}
+
+impl TestCommand {
+    pub(crate) fn new(program: impl AsRef<OsStr>) -> Self {
+        Self { command: Command::new(program), timeout: DEFAULT_TIMEOUT }
+    }
+
+    pub fn arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
+        self.command.arg(arg);
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.command.args(args);
+        self
+    }
+
+    pub fn env(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> &mut Self {
+        self.command.env(key, value);
+        self
+    }
+
+    pub(crate) fn envs<I, K, V>(&mut self, variables: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.command.envs(variables);
+        self
+    }
+
+    pub(crate) fn env_clear(&mut self) -> &mut Self {
+        self.command.env_clear();
+        self
+    }
+
+    pub fn current_dir(&mut self, directory: impl AsRef<Path>) -> &mut Self {
+        self.command.current_dir(directory);
+        self
+    }
+
+    pub fn timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn output(&mut self) -> io::Result<Output> {
+        self.command.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut child = spawn_command_group(&mut self.command)?;
+        let stdout = child.inner().stdout.take().map(read_pipe);
+        let stderr = child.inner().stderr.take().map(read_pipe);
+        let deadline = Instant::now() + self.timeout;
+
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(
+                        POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now())),
+                    );
+                }
+                Ok(None) => {
+                    let _ = child.kill();
+                    wait_for_group_exit(&mut child, Instant::now() + CLEANUP_TIMEOUT)?;
+                    collect_output(stdout, stderr, CLEANUP_TIMEOUT)?;
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("command timed out after {:?}", self.timeout),
+                    ));
+                }
+                Err(error) => {
+                    let _ = child.kill();
+                    return Err(error);
+                }
+            }
+        };
+
+        // A process leader can exit while a descendant still holds the output
+        // pipes. Terminating the residual group makes command completion and
+        // fixture teardown the same lifecycle boundary.
+        let _ = child.kill();
+        let (stdout, stderr) = collect_output(stdout, stderr, CLEANUP_TIMEOUT)?;
+        Ok(Output { status, stdout, stderr })
+    }
+
+    #[must_use]
+    pub fn assert(&mut self) -> assert_cmd::assert::Assert {
+        let output = self
+            .output()
+            .unwrap_or_else(|error| panic!("Failed to run {:?}: {error}", self.command));
+        assert_cmd::assert::Assert::new(output)
+            .append_context("command", format!("{:?}", self.command))
+    }
+}
+
+fn spawn_command_group(command: &mut Command) -> io::Result<GroupChild> {
+    #[cfg(windows)]
+    {
+        command.group().kill_on_drop(true).spawn()
+    }
+    #[cfg(not(windows))]
+    {
+        command.group_spawn()
+    }
+}
+
+fn read_pipe(mut pipe: impl Read + Send + 'static) -> Receiver<io::Result<Vec<u8>>> {
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        let result = pipe.read_to_end(&mut output).map(|_| output);
+        let _ = sender.send(result);
+    });
+    receiver
+}
+
+fn wait_for_group_exit(child: &mut GroupChild, deadline: Instant) -> io::Result<ExitStatus> {
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "command group did not terminate after it was killed",
+            ));
+        }
+        thread::sleep(POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now())));
+    }
+}
+
+fn collect_output(
+    stdout: Option<Receiver<io::Result<Vec<u8>>>>,
+    stderr: Option<Receiver<io::Result<Vec<u8>>>>,
+    timeout: Duration,
+) -> io::Result<(Vec<u8>, Vec<u8>)> {
+    let deadline = Instant::now() + timeout;
+    let stdout = receive_pipe(stdout, deadline, "stdout")?;
+    let stderr = receive_pipe(stderr, deadline, "stderr")?;
+    Ok((stdout, stderr))
+}
+
+fn receive_pipe(
+    pipe: Option<Receiver<io::Result<Vec<u8>>>>,
+    deadline: Instant,
+    name: &str,
+) -> io::Result<Vec<u8>> {
+    let Some(pipe) = pipe else { return Ok(Vec::new()) };
+    match pipe.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout) => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("timed out collecting command {name}"),
+        )),
+        Err(RecvTimeoutError::Disconnected) => {
+            Err(io::Error::other(format!("command {name} reader exited without a result")))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, process::Command, thread, time::Instant};
+
+    use super::*;
+
+    const DESCENDANT_TEST_MODE: &str = "GHERRIT_DESCENDANT_TIMEOUT_TEST";
+
+    #[test]
+    fn terminates_descendants_on_timeout() {
+        match env::var(DESCENDANT_TEST_MODE).as_deref() {
+            Ok("parent") => {
+                let mut leaf = Command::new(env::current_exe().unwrap())
+                    .args([
+                        "--exact",
+                        "command::tests::terminates_descendants_on_timeout",
+                        "--nocapture",
+                    ])
+                    .env(DESCENDANT_TEST_MODE, "leaf")
+                    .spawn()
+                    .unwrap();
+                leaf.wait().unwrap();
+                return;
+            }
+            Ok("leaf") => {
+                thread::sleep(Duration::from_secs(2));
+                return;
+            }
+            _ => {}
+        }
+
+        let mut command = TestCommand::new(env::current_exe().unwrap());
+        command
+            .args(["--exact", "command::tests::terminates_descendants_on_timeout", "--nocapture"])
+            .env(DESCENDANT_TEST_MODE, "parent")
+            .timeout(Duration::from_millis(100));
+
+        let started = Instant::now();
+        let error = command.output().unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "descendant retained command output pipes for {:?}",
+            started.elapsed()
+        );
+    }
+}

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -1,20 +1,27 @@
 use std::{
+    any::Any,
     collections::HashMap,
     env,
     ffi::OsString,
-    fs,
+    fmt, fs, panic,
     path::{Path, PathBuf},
     process::Command,
     sync::{
         atomic::{AtomicU64, Ordering},
+        mpsc::{self, Receiver, RecvTimeoutError},
         Arc, LazyLock, RwLock,
     },
+    thread,
+    time::Duration,
 };
 
 use regex::Regex;
 use tempfile::TempDir;
 
+mod command;
 pub mod mock_server;
+
+pub use command::TestCommand;
 
 pub const DEFAULT_OWNER: &str = "owner";
 pub const DEFAULT_REPO: &str = "repo";
@@ -22,6 +29,9 @@ pub const MANAGED_PRIVATE: &str = "managedPrivate";
 pub const MANAGED_PUBLIC: &str = "managedPublic";
 
 const FIRST_GIT_TIMESTAMP: u64 = 946_684_800;
+const MOCK_BIN_BUILD_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const MOCK_SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+const MOCK_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[macro_export]
 macro_rules! test_context {
@@ -37,18 +47,15 @@ pub fn build_mock_bin() -> PathBuf {
         let target_dir = manifest_dir.parent().unwrap().join("target").join("mock_bin_build");
 
         eprintln!("Building mock_bin at {:?}", manifest_dir);
-        let status = Command::new("cargo")
+        TestCommand::new("cargo")
             .args(["build", "--bin", "mock_bin"])
             .arg("--manifest-path")
             .arg(manifest_dir.join("Cargo.toml"))
             .arg("--target-dir")
             .arg(&target_dir)
-            .status()
-            .expect("Failed to execute cargo build for mock_bin");
-
-        if !status.success() {
-            panic!("Failed to build mock_bin. See stdout/stderr for details.");
-        }
+            .timeout(MOCK_BIN_BUILD_TIMEOUT)
+            .assert()
+            .success();
 
         target_dir.join("debug").join(if cfg!(windows) { "mock_bin.exe" } else { "mock_bin" })
     });
@@ -124,7 +131,7 @@ impl TestContextBuilder {
             panic!("Missing GHERRIT_TEST_BUILD environment variable");
         }
 
-        let dir = TempDir::new().unwrap();
+        let dir = Arc::new(TempDir::new().unwrap());
         let system_git = SYSTEM_GIT.clone();
         let test_environment = TestEnvironment::new(dir.path(), &system_git);
         let repo_path = dir.path().join("local");
@@ -158,37 +165,13 @@ impl TestContextBuilder {
             let state = Arc::new(RwLock::new(state));
             mock_server_state = Some(state.clone());
 
-            // Spawn the server on a separate thread to avoid blocking the main
-            // test thread. This ensures the runtime persists for the duration
-            // of the test context.
-
-            let (tx, rx) = std::sync::mpsc::channel();
-            let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-
-            let state_for_server = state.clone();
-            let remote_path_for_server = remote_path.clone();
-            let system_git_for_server = system_git.clone();
-            let git_environment_for_server = test_environment.variables.clone();
-            std::thread::spawn(move || {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("Failed to build runtime");
-
-                rt.block_on(async {
-                    let url = mock_server::start_mock_server(
-                        state_for_server,
-                        remote_path_for_server,
-                        system_git_for_server,
-                        git_environment_for_server,
-                    )
-                    .await;
-                    tx.send(url).expect("Failed to send mock server URL");
-                    let _ = shutdown_rx.await;
-                });
-            });
-
-            MockServerInfo { url: rx.recv().unwrap(), shutdown_tx }
+            MockServerInfo::start(
+                state,
+                remote_path.clone(),
+                system_git.clone(),
+                test_environment.clone(),
+                dir.clone(),
+            )
         });
 
         let ctx = TestContext {
@@ -222,7 +205,7 @@ impl TestContextBuilder {
 }
 
 pub struct TestContext {
-    pub dir: TempDir,
+    pub dir: Arc<TempDir>,
     pub repo_path: PathBuf,
     pub system_git: PathBuf,
     pub gherrit_bin_path: PathBuf,
@@ -344,14 +327,14 @@ impl TestEnvironment {
         Self { variables }
     }
 
-    fn apply_to_assert_cmd(&self, cmd: &mut assert_cmd::Command) {
+    fn apply_to_command(&self, cmd: &mut TestCommand) {
         cmd.env_clear();
         cmd.envs(self.variables.iter().cloned());
     }
 
-    fn command(&self, program: &Path) -> assert_cmd::Command {
-        let mut cmd = assert_cmd::Command::new(program);
-        self.apply_to_assert_cmd(&mut cmd);
+    fn command(&self, program: &Path) -> TestCommand {
+        let mut cmd = TestCommand::new(program);
+        self.apply_to_command(&mut cmd);
         cmd
     }
 }
@@ -364,7 +347,123 @@ fn push_unique_path(paths: &mut Vec<PathBuf>, path: &Path) {
 
 pub struct MockServerInfo {
     pub url: String,
-    pub shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    completion_rx: Option<Receiver<thread::Result<()>>>,
+}
+
+enum MockServerStopError {
+    Panicked(Box<dyn Any + Send + 'static>),
+    TimedOut(Duration),
+    Disconnected,
+}
+
+impl fmt::Display for MockServerStopError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Panicked(_) => formatter.write_str("mock server thread panicked"),
+            Self::TimedOut(timeout) => {
+                write!(formatter, "mock server did not stop within {timeout:?}")
+            }
+            Self::Disconnected => {
+                formatter.write_str("mock server thread exited without reporting its result")
+            }
+        }
+    }
+}
+
+impl MockServerInfo {
+    fn start(
+        state: Arc<RwLock<mock_server::MockState>>,
+        remote_path: PathBuf,
+        system_git: PathBuf,
+        test_environment: TestEnvironment,
+        fixture_dir: Arc<TempDir>,
+    ) -> Self {
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let (completion_tx, completion_rx) = mpsc::channel();
+
+        thread::Builder::new()
+            .name("gherrit-mock-server".to_string())
+            .spawn(move || {
+                let result = panic::catch_unwind(panic::AssertUnwindSafe(move || {
+                    // Keep the fixture directory alive if this thread must be
+                    // detached after a pathological shutdown timeout.
+                    let _fixture_dir = fixture_dir;
+                    let runtime = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .expect("Failed to build mock server runtime");
+                    runtime.block_on(mock_server::run_mock_server(
+                        state,
+                        remote_path,
+                        system_git,
+                        test_environment,
+                        ready_tx,
+                        shutdown_rx,
+                    ));
+                }));
+                let _ = completion_tx.send(result);
+            })
+            .expect("Failed to spawn mock server thread");
+
+        let url = match ready_rx.recv_timeout(MOCK_SERVER_STARTUP_TIMEOUT) {
+            Ok(url) => url,
+            Err(startup_error) => match Self::stop(Some(shutdown_tx), &completion_rx) {
+                Ok(()) => panic!(
+                    "Mock server did not become ready within \
+                     {MOCK_SERVER_STARTUP_TIMEOUT:?}: {startup_error}"
+                ),
+                Err(MockServerStopError::Panicked(server_panic)) => {
+                    panic::resume_unwind(server_panic)
+                }
+                Err(stop_error) => panic!(
+                    "Mock server did not become ready within \
+                     {MOCK_SERVER_STARTUP_TIMEOUT:?}: {startup_error}; {stop_error}"
+                ),
+            },
+        };
+
+        Self { url, shutdown_tx: Some(shutdown_tx), completion_rx: Some(completion_rx) }
+    }
+
+    fn stop(
+        shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        completion_rx: &Receiver<thread::Result<()>>,
+    ) -> Result<(), MockServerStopError> {
+        if let Some(shutdown_tx) = shutdown_tx {
+            let _ = shutdown_tx.send(());
+        }
+
+        wait_for_server_completion(completion_rx, MOCK_SERVER_SHUTDOWN_TIMEOUT)
+    }
+}
+
+fn wait_for_server_completion(
+    completion_rx: &Receiver<thread::Result<()>>,
+    timeout: Duration,
+) -> Result<(), MockServerStopError> {
+    match completion_rx.recv_timeout(timeout) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(server_panic)) => Err(MockServerStopError::Panicked(server_panic)),
+        Err(RecvTimeoutError::Timeout) => Err(MockServerStopError::TimedOut(timeout)),
+        Err(RecvTimeoutError::Disconnected) => Err(MockServerStopError::Disconnected),
+    }
+}
+
+impl Drop for MockServerInfo {
+    fn drop(&mut self) {
+        let completion_rx = self.completion_rx.take().expect("mock server completion receiver");
+        if let Err(error) = Self::stop(self.shutdown_tx.take(), &completion_rx) {
+            if thread::panicking() {
+                eprintln!("Mock server teardown also failed: {error}");
+            } else if let MockServerStopError::Panicked(server_panic) = error {
+                panic::resume_unwind(server_panic);
+            } else {
+                panic!("Mock server teardown failed: {error}");
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -376,15 +475,14 @@ pub enum FailureKind {
 
 impl Drop for TestContext {
     fn drop(&mut self) {
-        if let Some(server) = self.mock_server.take() {
-            let _ = server.shutdown_tx.send(());
-        }
+        // Stop the server before fixture directories and state are released.
+        drop(self.mock_server.take());
     }
 }
 
 impl TestContext {
-    fn configure_test_env(&self, cmd: &mut assert_cmd::Command) {
-        self.test_environment.apply_to_assert_cmd(cmd);
+    fn configure_test_env(&self, cmd: &mut TestCommand) {
+        self.test_environment.apply_to_command(cmd);
 
         // Give each command a deterministic, unique timestamp. In particular,
         // this ensures an otherwise-empty amend creates a distinct Git object.
@@ -411,9 +509,9 @@ impl TestContext {
     }
 
     #[must_use = "command builders do nothing until executed"]
-    pub fn gherrit_cmd(&self) -> assert_cmd::Command {
+    pub fn gherrit_cmd(&self) -> TestCommand {
         // Use injected binary path
-        let mut cmd = assert_cmd::Command::new(&self.gherrit_bin_path);
+        let mut cmd = TestCommand::new(&self.gherrit_bin_path);
         cmd.current_dir(&self.repo_path);
 
         self.configure_test_env(&mut cmd);
@@ -422,9 +520,9 @@ impl TestContext {
     }
 
     #[must_use = "command builders do nothing until executed"]
-    pub fn remote_git_cmd(&self) -> assert_cmd::Command {
+    pub fn remote_git_cmd(&self) -> TestCommand {
         assert!(self.has_remote, "missing test capability: .with_remote()");
-        let mut cmd = assert_cmd::Command::new(&self.system_git);
+        let mut cmd = TestCommand::new(&self.system_git);
         cmd.current_dir(&self.remote_path);
         self.configure_test_env(&mut cmd);
         cmd
@@ -435,8 +533,8 @@ impl TestContext {
     }
 
     #[must_use = "command builders do nothing until executed"]
-    pub fn git_cmd(&self) -> assert_cmd::Command {
-        let mut cmd = assert_cmd::Command::new("git");
+    pub fn git_cmd(&self) -> TestCommand {
+        let mut cmd = TestCommand::new("git");
         cmd.current_dir(&self.repo_path);
         self.configure_test_env(&mut cmd);
         cmd
@@ -634,21 +732,21 @@ impl TestContext {
     }
 
     #[must_use = "command builders do nothing until executed"]
-    pub fn hook_cmd(&self, name: &str) -> assert_cmd::Command {
+    pub fn hook_cmd(&self, name: &str) -> TestCommand {
         let mut cmd = self.gherrit_cmd();
         cmd.args(["hook", name]);
         cmd
     }
 
     #[must_use = "command builders do nothing until executed"]
-    pub fn manage_cmd(&self) -> assert_cmd::Command {
+    pub fn manage_cmd(&self) -> TestCommand {
         let mut cmd = self.gherrit_cmd();
         cmd.arg("manage");
         cmd
     }
 
     #[must_use = "command builders do nothing until executed"]
-    pub fn unmanage_cmd(&self) -> assert_cmd::Command {
+    pub fn unmanage_cmd(&self) -> TestCommand {
         let mut cmd = self.gherrit_cmd();
         cmd.arg("unmanage");
         cmd
@@ -713,17 +811,17 @@ fn normalize_git_diagnostic_separators(output: &str) -> String {
 }
 
 pub trait IntoCommandRef {
-    fn as_command_mut(&mut self) -> &mut assert_cmd::Command;
+    fn as_command_mut(&mut self) -> &mut TestCommand;
 }
 
-impl IntoCommandRef for assert_cmd::Command {
-    fn as_command_mut(&mut self) -> &mut assert_cmd::Command {
+impl IntoCommandRef for TestCommand {
+    fn as_command_mut(&mut self) -> &mut TestCommand {
         self
     }
 }
 
-impl IntoCommandRef for &mut assert_cmd::Command {
-    fn as_command_mut(&mut self) -> &mut assert_cmd::Command {
+impl IntoCommandRef for &mut TestCommand {
+    fn as_command_mut(&mut self) -> &mut TestCommand {
         self
     }
 }
@@ -791,6 +889,8 @@ fn apply_literal_redactions<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
 
     #[test]
@@ -831,15 +931,60 @@ mod tests {
     fn test_environment_clears_inherited_values() {
         let root = TempDir::new().unwrap();
         let environment = TestEnvironment::new(root.path(), SYSTEM_GIT.as_path());
-        let mut command = assert_cmd::Command::new("/usr/bin/env");
+        let mut command = TestCommand::new("/usr/bin/env");
         command.env("SHOULD_BE_CLEARED", "yes");
-        environment.apply_to_assert_cmd(&mut command);
+        environment.apply_to_command(&mut command);
 
         let assert = command.assert().success();
         let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
         assert!(!output.contains("SHOULD_BE_CLEARED="));
         assert!(output.lines().any(|line| line == "RUST_LOG=info"));
         assert!(output.lines().any(|line| line.starts_with("HOME=")));
+    }
+
+    #[test]
+    fn server_completion_wait_is_bounded() {
+        let (_completion_tx, completion_rx) = mpsc::channel();
+        let timeout = Duration::from_millis(20);
+        let started = Instant::now();
+
+        let error = wait_for_server_completion(&completion_rx, timeout).unwrap_err();
+
+        assert!(matches!(error, MockServerStopError::TimedOut(value) if value == timeout));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn server_completion_propagates_panics() {
+        let (completion_tx, completion_rx): (_, Receiver<thread::Result<()>>) = mpsc::channel();
+        assert!(completion_tx.send(Err(Box::new("server panic"))).is_ok());
+
+        let error = wait_for_server_completion(&completion_rx, Duration::from_secs(1)).unwrap_err();
+
+        let MockServerStopError::Panicked(payload) = error else {
+            panic!("expected server panic result");
+        };
+        assert_eq!(payload.downcast_ref::<&str>(), Some(&"server panic"));
+    }
+
+    #[test]
+    fn dropping_mock_server_waits_for_state_release() {
+        let state = Arc::new(RwLock::new(mock_server::MockState::default()));
+        let weak_state = Arc::downgrade(&state);
+        let test_dir = Arc::new(TempDir::new().unwrap());
+        let system_git = SYSTEM_GIT.clone();
+        let test_environment = TestEnvironment::new(test_dir.path(), &system_git);
+        let server = MockServerInfo::start(
+            state,
+            test_dir.path().join("remote.git"),
+            system_git,
+            test_environment,
+            test_dir,
+        );
+
+        assert!(weak_state.upgrade().is_some());
+        drop(server);
+        assert!(weak_state.upgrade().is_none(), "mock server retained state after teardown");
     }
 }
 

--- a/testutil/src/mock_server.rs
+++ b/testutil/src/mock_server.rs
@@ -1,9 +1,8 @@
 use std::{
     collections::{HashMap, HashSet},
-    ffi::OsString,
+    future::IntoFuture,
     path::PathBuf,
-    process::Command,
-    sync::{Arc, RwLock},
+    sync::{mpsc::Sender, Arc, RwLock},
 };
 
 use apollo_compiler::{ast, executable, validation::Valid, ExecutableDocument, Name, Node};
@@ -11,7 +10,7 @@ use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
-use crate::FailureKind;
+use crate::{FailureKind, TestEnvironment};
 
 #[derive(Debug, Clone, Default)]
 pub struct MockState {
@@ -198,22 +197,23 @@ struct AppState {
     state: Arc<RwLock<MockState>>,
     remote_path: PathBuf,
     system_git: PathBuf,
-    git_environment: Vec<(OsString, OsString)>,
+    test_environment: TestEnvironment,
 }
 
-/// Starts a mock GitHub API server on a random local port.
-/// Returns the address of the running server (e.g., `http://127.0.0.1:12345`).
-pub async fn start_mock_server(
+/// Runs a mock GitHub API server until `shutdown_rx` is signaled.
+pub(super) async fn run_mock_server(
     state: Arc<RwLock<MockState>>,
     remote_path: PathBuf,
     system_git: PathBuf,
-    git_environment: Vec<(OsString, OsString)>,
-) -> String {
+    test_environment: TestEnvironment,
+    ready_tx: Sender<String>,
+    shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let url = format!("http://{}", addr);
 
-    let app_state = AppState { state, remote_path, system_git, git_environment };
+    let app_state = AppState { state, remote_path, system_git, test_environment };
 
     let app = Router::new()
         .route("/graphql", post(graphql))
@@ -221,11 +221,14 @@ pub async fn start_mock_server(
         .route("/_internal/git/complete", post(complete_git))
         .with_state(app_state);
 
-    tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
+    ready_tx.send(url).expect("Failed to send mock server URL");
 
-    url
+    let server = axum::serve(listener, app).into_future();
+    tokio::pin!(server);
+    tokio::select! {
+        result = &mut server => result.unwrap(),
+        _ = shutdown_rx => {}
+    }
 }
 
 fn check_and_apply_graphql_failure(
@@ -737,7 +740,7 @@ mod git_tests {
             state: Arc::new(RwLock::new(MockState::new("owner".to_string(), "repo".to_string()))),
             remote_path: PathBuf::new(),
             system_git: PathBuf::from("git"),
-            git_environment: Vec::new(),
+            test_environment: TestEnvironment { variables: Vec::new() },
         }
     }
 
@@ -934,15 +937,15 @@ fn graphql_http_error(message: &str) -> (StatusCode, Json<serde_json::Value>) {
 
 fn remote_branch_exists(app_state: &AppState, branch: &str) -> Result<bool, String> {
     let reference = format!("refs/heads/{branch}");
-    let mut command = Command::new(&app_state.system_git);
-    command.env_clear().envs(app_state.git_environment.iter().cloned());
-    let status = command
+    let output = app_state
+        .test_environment
+        .command(&app_state.system_git)
         .arg("--git-dir")
         .arg(&app_state.remote_path)
         .args(["show-ref", "--verify", "--quiet", &reference])
-        .status()
+        .output()
         .map_err(|error| format!("Failed to inspect remote Git ref `{reference}`: {error}"))?;
-    match status.code() {
+    match output.status.code() {
         Some(0) => Ok(true),
         Some(1) => Ok(false),
         code => Err(format!("Inspecting remote Git ref `{reference}` exited with {code:?}")),


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Test commands and mock server threads could outlive their fixtures,
turning failures into hangs and allowing server state to race teardown.

Give ordinary commands one deadline and recursive mock builds a longer
one. Run each command in a process group or Windows job, terminate the
whole tree on timeout, and bound captured-output cleanup.

Cancel the mock server when its fixture drops and wait on a bounded
completion handshake after its runtime and state are released. Retain
the fixture directory if a pathological worker must be detached, and
avoid a second panic while another failure unwinds.

Cover descendant pipe retention, bounded completion, panic propagation,
and final state release.




---

- 　  #308
- 　  #307
- 👉 #306


**Latest Update:** v14 — [Compare vs v13](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v13 | v12 | v11 | v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v14|[v13](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v12](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v11](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v10](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v9](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v8](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v7](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v6](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v14)|
|v13||[v12](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v11](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v10](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v9](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v8](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v7](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v6](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v13)|
|v12|||[v11](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v10](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v9](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v8](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v7](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v6](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v12)|
|v11||||[v10](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v9](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v8](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v7](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v6](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v11)|
|v10|||||[v9](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[v8](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[v7](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[v6](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v10)|
|v9||||||[v8](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|[v7](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|[v6](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v9)|
|v8|||||||[v7](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8)|[v6](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8)|[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v8)|
|v7||||||||[v6](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7)|[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v7)|
|v6|||||||||[v5](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6)|[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v6)|
|v5||||||||||[v4](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5)|[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v5)|
|v4|||||||||||[v3](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4)|[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v4)|
|v3||||||||||||[v2](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3)|[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v3)|
|v2|||||||||||||[v1](/joshlf/gherrit/compare/gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2)|[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v2)|
|v1||||||||||||||[Base](/joshlf/gherrit/compare/main..gherrit/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb && git checkout -b pr-Gj6lbygq3nohmq3o7amv4pg2eqezbczmb FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gj6lbygq3nohmq3o7amv4pg2eqezbczmb
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gj6lbygq3nohmq3o7amv4pg2eqezbczmb", "parent": null, "child": "Gfzgw7fwwu5hq3tfrhoqaqi5enktsdl7f"}" -->