### PR TITLE
[pre-push] Extract PR reconciliation model

### DIFF
--- a/src/pre_push.rs
+++ b/src/pre_push.rs
@@ -17,6 +17,10 @@ use crate::{
     util::{self, CommandExt as _, HeadState, Remote},
 };
 
+mod reconcile;
+
+use reconcile::{CurrentPr, DesiredPr, PrUpdate, link_stack, plan_update};
+
 pub async fn run(repo: &util::Repo) -> Result<()> {
     let branch_name = repo.current_branch();
     let branch_name = match branch_name {
@@ -555,14 +559,7 @@ async fn sync_prs(
 ) -> Result<()> {
     let remote = repo.default_remote()?;
 
-    let commits = commits
-        .into_iter()
-        .scan(base_branch.to_string(), |parent_branch, c| {
-            let parent = parent_branch.clone();
-            *parent_branch = c.gherrit_id.clone();
-            Some((c, parent))
-        })
-        .collect::<Vec<_>>();
+    let commits = link_stack(base_branch, commits, |commit| commit.gherrit_id.clone());
 
     enum PrResolution {
         Existing(PrState),
@@ -572,7 +569,8 @@ async fn sync_prs(
     // 1. Identify existing PRs or queue for creation
     let resolutions: Vec<_> = commits
         .iter()
-        .map(|(c, parent_branch)| {
+        .map(|entry| {
+            let c = &entry.item;
             let pr_info = prs.iter().find(|pr| pr.head_branch == c.gherrit_id);
 
             if let Some(pr) = pr_info {
@@ -583,7 +581,7 @@ async fn sync_prs(
                 Ok(PrResolution::ToCreate(BatchCreate {
                     title: c.message_title.clone(),
                     body: c.message_body.clone(),
-                    base_branch: parent_branch.clone(),
+                    base_branch: entry.base_branch.clone(),
                     head_branch: c.gherrit_id.clone(),
                 }))
             }
@@ -614,7 +612,7 @@ async fn sync_prs(
     let commit_pr_states = commits
         .iter()
         .zip(resolutions)
-        .map(|((c, parent_branch), resolution)| {
+        .map(|(entry, resolution)| {
             let pr_state = match resolution {
                 PrResolution::Existing(state) => state,
                 PrResolution::ToCreate(create) => {
@@ -636,7 +634,7 @@ async fn sync_prs(
                     }
                 }
             };
-            Ok((c, parent_branch, pr_state))
+            Ok((entry, pr_state))
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -649,14 +647,15 @@ async fn sync_prs(
         })
         .flatten();
 
-    let updates: Vec<BatchUpdate> = commit_pr_states
+    let repo_url = remote.repo_url_relative();
+    let updates: Vec<PrUpdate> = commit_pr_states
         .iter()
-        .enumerate()
-        .filter_map(|(i, (c, parent_branch, pr_state))| {
+        .filter_map(|(entry, pr_state)| {
+            let c = &entry.item;
             let gh_pr_ids_markdown = commit_pr_states
                 .iter()
                 .rev()
-                .map(|(_, _, state)| {
+                .map(|(_, state)| {
                     let prefix =
                         if state.number == pr_state.number { "👉" } else { "\u{3000}\u{2009}" };
                     format!("- {} #{}", prefix, state.number)
@@ -666,46 +665,39 @@ async fn sync_prs(
 
             let latest_version = latest_versions.get(&c.gherrit_id).copied().unwrap_or(1);
 
-            let parent_gherrit_id = (i > 0).then(|| commit_pr_states[i - 1].0.gherrit_id.clone());
-            let child_gherrit_id = (i < commit_pr_states.len() - 1)
-                .then(|| commit_pr_states[i + 1].0.gherrit_id.clone());
-
             let body = (PrBodyBuilder {
                 c,
-                repo_url: &remote.repo_url_relative(),
+                repo_url: &repo_url,
                 head_branch_markdown: head_branch_markdown.as_deref(),
                 gh_pr_ids_markdown: &gh_pr_ids_markdown,
                 latest_version,
-                base_branch: parent_branch,
-                parent_id: parent_gherrit_id.as_deref(),
-                child_id: child_gherrit_id.as_deref(),
+                base_branch: &entry.base_branch,
+                parent_id: entry.parent_id.as_deref(),
+                child_id: entry.child_id.as_deref(),
             })
             .build();
 
             let pr_num = pr_state.number.green().bold().to_string();
             let pr_url = remote.pr_url(pr_state.number).blue().underline().to_string();
 
-            let title =
-                (pr_state.title != Some(c.message_title.clone())).then(|| c.message_title.clone());
-            let body = {
-                let body_changed = pr_state.body.as_ref().is_none_or(|b| {
-                    b.replace("\r\n", "\n").trim() != body.replace("\r\n", "\n").trim()
-                });
-                body_changed.then(|| body.clone())
-            };
-            let base_branch =
-                (pr_state.base_branch != parent_branch.as_str()).then(|| parent_branch.to_string());
+            let update = plan_update(
+                CurrentPr {
+                    node_id: &pr_state.node_id,
+                    title: pr_state.title.as_deref(),
+                    body: pr_state.body.as_deref(),
+                    base_branch: &pr_state.base_branch,
+                },
+                DesiredPr { title: &c.message_title, body: &body, base_branch: &entry.base_branch },
+            );
 
-            let changed = base_branch.is_some() || title.is_some() || body.is_some();
-
-            if changed {
+            if update.is_some() {
                 log::debug!("Queuing update for PR #{}", pr_num);
                 log::info!("Queued update for PR #{}: {}", pr_num, pr_url);
-                Some(BatchUpdate { node_id: pr_state.node_id.clone(), title, body, base_branch })
             } else {
                 log::info!("PR #{} is up to date: {}", pr_num, pr_url);
-                None
             }
+
+            update
         })
         .collect();
 
@@ -754,20 +746,6 @@ impl TryFrom<gix::Commit<'_>> for Commit {
 }
 
 re!(gherrit_pr_id_re, r"(?m)^gherrit-pr-id: ([a-zA-Z0-9]*)$");
-
-/// A request to update an existing PR in a batch.
-struct BatchUpdate {
-    /// The global Node ID of the Pull Request (required for GraphQL mutations).
-    node_id: String,
-    title: Option<String>,
-    body: Option<String>,
-    // NOTE: Omitting updates to the base branch is not just an optimization -
-    // when a PR is in the merge queue, updating the base branch will cause
-    // GitHub to reject the update (even if it's a no-op update which updates
-    // the base to a value identical to its current value). Omitting the base
-    // branch field in that case allows the update to succeed. See #271.
-    base_branch: Option<String>,
-}
 
 /// A request to create a new PR in a batch.
 #[derive(Clone)]
@@ -862,7 +840,7 @@ async fn fetch_repo_id(octocrab: &Octocrab, remote: &Remote) -> Result<String> {
 ///
 /// This avoids rate limits and network latency by grouping updates into chunks
 /// (default 50) and sending them as a single GraphQL operation.
-async fn batch_update_prs(octocrab: &Octocrab, updates: Vec<BatchUpdate>) -> Result<()> {
+async fn batch_update_prs(octocrab: &Octocrab, updates: Vec<PrUpdate>) -> Result<()> {
     run_batched_graphql(
         octocrab,
         GraphQlOp::Mutation,

--- a/src/pre_push/reconcile.rs
+++ b/src/pre_push/reconcile.rs
@@ -1,0 +1,285 @@
+/// A stack item annotated with the relationships needed to project it as a PR.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct StackEntry<T> {
+    pub(super) item: T,
+    pub(super) base_branch: String,
+    pub(super) parent_id: Option<String>,
+    pub(super) child_id: Option<String>,
+}
+
+/// Derives stack topology from items ordered from base to head.
+pub(super) fn link_stack<T>(
+    base_branch: &str,
+    items: impl IntoIterator<Item = T>,
+    id_of: impl Fn(&T) -> String,
+) -> Vec<StackEntry<T>> {
+    let mut items = items.into_iter().peekable();
+    let mut parent_id = None;
+    let mut parent_branch = base_branch.to_string();
+    let mut stack = Vec::new();
+
+    while let Some(item) = items.next() {
+        let id = id_of(&item);
+        let child_id = items.peek().map(&id_of);
+        stack.push(StackEntry {
+            item,
+            base_branch: parent_branch,
+            parent_id: parent_id.clone(),
+            child_id,
+        });
+        parent_branch = id.clone();
+        parent_id = Some(id);
+    }
+
+    stack
+}
+
+/// Metadata currently stored on a PR.
+pub(super) struct CurrentPr<'a> {
+    pub(super) node_id: &'a str,
+    pub(super) title: Option<&'a str>,
+    pub(super) body: Option<&'a str>,
+    pub(super) base_branch: &'a str,
+}
+
+/// Metadata derived from a local commit and its stack position.
+pub(super) struct DesiredPr<'a> {
+    pub(super) title: &'a str,
+    pub(super) body: &'a str,
+    pub(super) base_branch: &'a str,
+}
+
+/// The fields that must be changed to reconcile a PR.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct PrUpdate {
+    /// The global node ID of the PR to update.
+    pub(super) node_id: String,
+    pub(super) title: Option<String>,
+    pub(super) body: Option<String>,
+    // Omitting an unchanged base branch is required for PRs in the merge queue:
+    // GitHub rejects even a no-op base update for those PRs. See #271.
+    pub(super) base_branch: Option<String>,
+}
+
+/// Returns the minimal update needed to make `current` match `desired`.
+pub(super) fn plan_update(current: CurrentPr<'_>, desired: DesiredPr<'_>) -> Option<PrUpdate> {
+    let title = (current.title != Some(desired.title)).then(|| desired.title.to_string());
+    let body_changed =
+        current.body.is_none_or(|body| normalize_body(body) != normalize_body(desired.body));
+    let body = body_changed.then(|| desired.body.to_string());
+    let base_branch =
+        (current.base_branch != desired.base_branch).then(|| desired.base_branch.to_string());
+
+    (title.is_some() || body.is_some() || base_branch.is_some()).then(|| PrUpdate {
+        node_id: current.node_id.to_string(),
+        title,
+        body,
+        base_branch,
+    })
+}
+
+fn normalize_body(body: &str) -> String {
+    body.replace("\r\n", "\n").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn link_ids(base_branch: &str, ids: &[&str]) -> Vec<StackEntry<String>> {
+        link_stack(base_branch, ids.iter().map(|id| (*id).to_string()), Clone::clone)
+    }
+
+    #[test]
+    fn links_an_empty_stack() {
+        assert_eq!(link_ids("main", &[]), []);
+    }
+
+    #[test]
+    fn links_a_single_commit_to_the_base() {
+        assert_eq!(
+            link_ids("main", &["A"]),
+            [StackEntry {
+                item: "A".to_string(),
+                base_branch: "main".to_string(),
+                parent_id: None,
+                child_id: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn links_each_commit_to_its_neighbors() {
+        assert_eq!(
+            link_ids("main", &["A", "B", "C"]),
+            [
+                StackEntry {
+                    item: "A".to_string(),
+                    base_branch: "main".to_string(),
+                    parent_id: None,
+                    child_id: Some("B".to_string()),
+                },
+                StackEntry {
+                    item: "B".to_string(),
+                    base_branch: "A".to_string(),
+                    parent_id: Some("A".to_string()),
+                    child_id: Some("C".to_string()),
+                },
+                StackEntry {
+                    item: "C".to_string(),
+                    base_branch: "B".to_string(),
+                    parent_id: Some("B".to_string()),
+                    child_id: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn respects_a_custom_base() {
+        assert_eq!(
+            link_ids("release", &["A"]),
+            [StackEntry {
+                item: "A".to_string(),
+                base_branch: "release".to_string(),
+                parent_id: None,
+                child_id: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn preserves_input_order() {
+        assert_eq!(
+            link_ids("release", &["C", "A", "B"]),
+            [
+                StackEntry {
+                    item: "C".to_string(),
+                    base_branch: "release".to_string(),
+                    parent_id: None,
+                    child_id: Some("A".to_string()),
+                },
+                StackEntry {
+                    item: "A".to_string(),
+                    base_branch: "C".to_string(),
+                    parent_id: Some("C".to_string()),
+                    child_id: Some("B".to_string()),
+                },
+                StackEntry {
+                    item: "B".to_string(),
+                    base_branch: "A".to_string(),
+                    parent_id: Some("A".to_string()),
+                    child_id: None,
+                },
+            ]
+        );
+    }
+
+    fn current<'a>(
+        title: Option<&'a str>,
+        body: Option<&'a str>,
+        base_branch: &'a str,
+    ) -> CurrentPr<'a> {
+        CurrentPr { node_id: "PR_node", title, body, base_branch }
+    }
+
+    fn desired<'a>(title: &'a str, body: &'a str, base_branch: &'a str) -> DesiredPr<'a> {
+        DesiredPr { title, body, base_branch }
+    }
+
+    fn update(
+        title: Option<&str>,
+        body: Option<&str>,
+        base_branch: Option<&str>,
+    ) -> Option<PrUpdate> {
+        Some(PrUpdate {
+            node_id: "PR_node".to_string(),
+            title: title.map(ToString::to_string),
+            body: body.map(ToString::to_string),
+            base_branch: base_branch.map(ToString::to_string),
+        })
+    }
+
+    #[test]
+    fn omits_an_update_when_metadata_matches() {
+        assert_eq!(
+            plan_update(
+                current(Some("Title"), Some("Body"), "main"),
+                desired("Title", "Body", "main"),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn treats_line_endings_and_outer_whitespace_as_equivalent() {
+        assert_eq!(
+            plan_update(
+                current(Some("Title"), Some(" \r\nBody\r\n "), "main"),
+                desired("Title", "Body\n", "main"),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn preserves_meaningful_body_whitespace() {
+        assert_eq!(
+            plan_update(
+                current(Some("Title"), Some("Line one\n\nLine two"), "main"),
+                desired("Title", "Line one\nLine two", "main"),
+            ),
+            update(None, Some("Line one\nLine two"), None)
+        );
+    }
+
+    #[test]
+    fn plans_each_metadata_delta_independently() {
+        let cases = [
+            (
+                current(Some("Old"), Some("Body"), "main"),
+                desired("Title", "Body", "main"),
+                update(Some("Title"), None, None),
+            ),
+            (
+                current(Some("Title"), Some("Old"), "main"),
+                desired("Title", "Body", "main"),
+                update(None, Some("Body"), None),
+            ),
+            (
+                current(Some("Title"), Some("Body"), "old-base"),
+                desired("Title", "Body", "main"),
+                update(None, None, Some("main")),
+            ),
+            (
+                current(Some("Old"), Some("Old"), "old-base"),
+                desired("Title", "Body", "main"),
+                update(Some("Title"), Some("Body"), Some("main")),
+            ),
+        ];
+
+        for (current, desired, expected) in cases {
+            assert_eq!(plan_update(current, desired), expected);
+        }
+    }
+
+    #[test]
+    fn fills_in_missing_title_and_body() {
+        assert_eq!(
+            plan_update(current(None, None, "main"), desired("Title", "Body", "main"),),
+            update(Some("Title"), Some("Body"), None)
+        );
+    }
+
+    #[test]
+    fn omits_an_unchanged_base_from_other_updates() {
+        let update = plan_update(
+            current(Some("Old"), Some("Body"), "main"),
+            desired("Title", "Body", "main"),
+        )
+        .unwrap();
+
+        assert_eq!(update.title.as_deref(), Some("Title"));
+        assert_eq!(update.base_branch, None);
+    }
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

PR synchronization derived stack topology and metadata changes inside
its GitHub I/O loop, leaving those invariants covered only by
end-to-end tests.

Move topology and minimal-update planning into a pure model. Cover
empty and reordered stacks, parent, child, and base links,
field-specific updates, body normalization, missing metadata, and the
merge-queue requirement to omit unchanged base refs.




---

- 👉 #308


**Latest Update:** v12 — [Compare vs v11](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v11 | v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v12|[v11](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v10](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v9](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v8](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v7](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v6](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v5](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v4](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v12)|
|v11||[v10](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v9](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v8](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v7](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v6](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v5](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v4](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v11)|
|v10|||[v9](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[v8](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[v7](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[v6](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[v5](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[v4](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v10)|
|v9||||[v8](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|[v7](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|[v6](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|[v5](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|[v4](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v9)|
|v8|||||[v7](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8)|[v6](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8)|[v5](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8)|[v4](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8)|[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v8)|
|v7||||||[v6](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7)|[v5](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7)|[v4](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7)|[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v7)|
|v6|||||||[v5](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6)|[v4](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6)|[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v6)|
|v5||||||||[v4](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5)|[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v5)|
|v4|||||||||[v3](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4)|[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v4)|
|v3||||||||||[v2](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3)|[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v3)|
|v2|||||||||||[v1](/joshlf/gherrit/compare/gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2)|[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v2)|
|v1||||||||||||[Base](/joshlf/gherrit/compare/main..gherrit/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj && git checkout -b pr-G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G2xnuzz3bsuvz62qzgnqsxo2fygf7rwmj", "parent": null, "child": null}" -->