### PR TITLE
[pre-push] Refine reconciliation module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ It achieves this by:
 
 - `src/`: Core CLI source code.
     - `main.rs`: Entry point and CLI definition.
-    - `pre_push.rs`: **CORE LOGIC**. Handles the commit analysis, ref creation, pushing, and PR syncing.
+    - `pre_push/mod.rs`: **CORE LOGIC**. Handles commit analysis, ref creation,
+      pushing, and PR syncing.
     - `manage.rs`: Handles the state of branches (Managed vs Unmanaged) via `git config`.
     - `commit_msg.rs`: Ensures commits have `gherrit-pr-id` trailers.
 - `hooks/`: Git hooks (`pre-push`, `commit-msg`, `post-checkout`) that shell out to the `gherrit` binary.

--- a/src/pre_push/mod.rs
+++ b/src/pre_push/mod.rs
@@ -571,33 +571,36 @@ async fn sync_prs(
         .iter()
         .map(|entry| {
             let c = &entry.item;
-            let pr_info = prs.iter().find(|pr| pr.head_branch == c.gherrit_id);
 
-            if let Some(pr) = pr_info {
+            if let Some(pr) = prs.iter().find(|pr| pr.head_branch == c.gherrit_id) {
                 log::debug!("Found existing PR #{} for {}", pr.number.green().bold(), c.gherrit_id);
-                Ok(PrResolution::Existing(pr.clone()))
+                PrResolution::Existing(pr.clone())
             } else {
                 log::debug!("No GitHub PR exists for {}; queuing creation...", c.gherrit_id);
-                Ok(PrResolution::ToCreate(BatchCreate {
+                PrResolution::ToCreate(BatchCreate {
                     title: c.message_title.clone(),
                     body: c.message_body.clone(),
                     base_branch: entry.base_branch.clone(),
                     head_branch: c.gherrit_id.clone(),
-                }))
+                })
             }
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect();
 
     // 2. Batch create missing PRs
-    let creations = resolutions.iter().filter_map(|r| match r {
-        PrResolution::ToCreate(c) => Some(c),
-        _ => None,
-    });
-    let num_creations = creations.clone().count();
-    let new_prs = if num_creations > 0 {
+    let creations = resolutions
+        .iter()
+        .filter_map(|resolution| match resolution {
+            PrResolution::ToCreate(create) => Some(create),
+            PrResolution::Existing(_) => None,
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let num_creations = creations.len();
+    let new_prs = if !creations.is_empty() {
         log::info!("Creating {num_creations} PRs...");
         let repo_id = fetch_repo_id(octocrab, &remote).await?;
-        let created = batch_create_prs(octocrab, &repo_id, creations.cloned()).await?;
+        let created = batch_create_prs(octocrab, &repo_id, creations).await?;
         assert_eq!(created.len(), num_creations);
         log::info!("Created {num_creations} PRs.");
         created

--- a/src/pre_push/reconcile.rs
+++ b/src/pre_push/reconcile.rs
@@ -11,27 +11,26 @@ pub(super) struct StackEntry<T> {
 pub(super) fn link_stack<T>(
     base_branch: &str,
     items: impl IntoIterator<Item = T>,
-    id_of: impl Fn(&T) -> String,
+    mut id_of: impl FnMut(&T) -> String,
 ) -> Vec<StackEntry<T>> {
-    let mut items = items.into_iter().peekable();
-    let mut parent_id = None;
-    let mut parent_branch = base_branch.to_string();
-    let mut stack = Vec::new();
+    let mut items = items
+        .into_iter()
+        .map(|item| {
+            let id = id_of(&item);
+            (item, id)
+        })
+        .peekable();
+    let mut previous_id = None;
 
-    while let Some(item) = items.next() {
-        let id = id_of(&item);
-        let child_id = items.peek().map(&id_of);
-        stack.push(StackEntry {
-            item,
-            base_branch: parent_branch,
-            parent_id: parent_id.clone(),
-            child_id,
-        });
-        parent_branch = id.clone();
-        parent_id = Some(id);
-    }
+    std::iter::from_fn(|| {
+        let (item, id) = items.next()?;
+        let child_id = items.peek().map(|(_, id)| id.clone());
+        let parent_id = previous_id.replace(id);
+        let base_branch = parent_id.as_deref().unwrap_or(base_branch).to_owned();
 
-    stack
+        Some(StackEntry { item, base_branch, parent_id, child_id })
+    })
+    .collect()
 }
 
 /// Metadata currently stored on a PR.
@@ -64,9 +63,10 @@ pub(super) struct PrUpdate {
 /// Returns the minimal update needed to make `current` match `desired`.
 pub(super) fn plan_update(current: CurrentPr<'_>, desired: DesiredPr<'_>) -> Option<PrUpdate> {
     let title = (current.title != Some(desired.title)).then(|| desired.title.to_string());
-    let body_changed =
-        current.body.is_none_or(|body| normalize_body(body) != normalize_body(desired.body));
-    let body = body_changed.then(|| desired.body.to_string());
+    let body = current
+        .body
+        .is_none_or(|body| normalize_body(body) != normalize_body(desired.body))
+        .then(|| desired.body.to_string());
     let base_branch =
         (current.base_branch != desired.base_branch).then(|| desired.base_branch.to_string());
 
@@ -87,7 +87,7 @@ mod tests {
     use super::*;
 
     fn link_ids(base_branch: &str, ids: &[&str]) -> Vec<StackEntry<String>> {
-        link_stack(base_branch, ids.iter().map(|id| (*id).to_string()), Clone::clone)
+        link_stack(base_branch, ids.iter().copied().map(str::to_owned), Clone::clone)
     }
 
     #[test]
@@ -173,6 +173,17 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn extracts_each_id_once() {
+        let mut calls = 0;
+        let _ = link_stack("main", ["A", "B", "C"], |id| {
+            calls += 1;
+            (*id).to_owned()
+        });
+
+        assert_eq!(calls, 3);
     }
 
     fn current<'a>(


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The pre-push implementation now owns a submodule, but its root and
contributor documentation retained the single-file module form. The
extracted topology helper also used a mutable output loop, evaluated
lookahead IDs twice, and wrapped infallible PR resolution in Result.

Move the module root to src/pre_push/mod.rs and update its documented
location. Express topology as an iterator transformation, evaluate each
ID once, make the PR-resolution error boundary honest, and materialize
pending creations once before asynchronous creation.




---

- 👉 #309


**Latest Update:** v2 — [Compare vs v1](/joshlf/gherrit/compare/gherrit/Ghpddupyer4tz53nnu6xwzgs4uisclbhw/v1..gherrit/Ghpddupyer4tz53nnu6xwzgs4uisclbhw/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/joshlf/gherrit/compare/gherrit/Ghpddupyer4tz53nnu6xwzgs4uisclbhw/v1..gherrit/Ghpddupyer4tz53nnu6xwzgs4uisclbhw/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/Ghpddupyer4tz53nnu6xwzgs4uisclbhw/v2)|
|v1||[vs Base](/joshlf/gherrit/compare/main..gherrit/Ghpddupyer4tz53nnu6xwzgs4uisclbhw/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Ghpddupyer4tz53nnu6xwzgs4uisclbhw && git checkout -b pr-Ghpddupyer4tz53nnu6xwzgs4uisclbhw FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Ghpddupyer4tz53nnu6xwzgs4uisclbhw && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Ghpddupyer4tz53nnu6xwzgs4uisclbhw && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Ghpddupyer4tz53nnu6xwzgs4uisclbhw
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Ghpddupyer4tz53nnu6xwzgs4uisclbhw", "parent": null, "child": null}" -->