### PR TITLE
[tests] Share the GitHub schema

### DIFF
--- a/testutil/src/mock_server.rs
+++ b/testutil/src/mock_server.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     future::IntoFuture,
     path::PathBuf,
-    sync::{mpsc::Sender, Arc, RwLock},
+    sync::{mpsc::Sender, Arc, LazyLock, RwLock},
 };
 
 use apollo_compiler::{ast, executable, validation::Valid, ExecutableDocument, Name, Node};
@@ -11,6 +11,14 @@ use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
 use crate::{FailureKind, TestEnvironment};
+
+static GITHUB_SCHEMA: LazyLock<Valid<apollo_compiler::Schema>> = LazyLock::new(|| {
+    apollo_compiler::Schema::parse_and_validate(
+        include_str!("../data/github_schema.graphql"),
+        "github_schema.graphql",
+    )
+    .expect("Failed to parse and validate embedded GitHub schema")
+});
 
 #[derive(Debug, Clone, Default)]
 pub struct MockState {
@@ -21,7 +29,6 @@ pub struct MockState {
     pub repo_name: String,
     pub fail_next_request: Option<FailureKind>,
     pub merge_queue: HashSet<u64>,
-    pub schema: Option<Valid<apollo_compiler::Schema>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,12 +40,7 @@ pub enum GraphQlOperation {
 
 impl MockState {
     pub fn new(owner: String, name: String) -> Self {
-        let schema_src = include_str!("../data/github_schema.graphql");
-        let schema =
-            apollo_compiler::Schema::parse_and_validate(schema_src, "github_schema.graphql")
-                .expect("Failed to parse and validate embedded GitHub schema");
-
-        Self { repo_owner: owner, repo_name: name, schema: Some(schema), ..Default::default() }
+        Self { repo_owner: owner, repo_name: name, ..Default::default() }
     }
 
     pub fn add_pr(&mut self, pr: PrEntry) {
@@ -855,21 +857,20 @@ async fn graphql(
         Err(message) => return graphql_http_error(&message),
     };
 
-    let mut mock_state = app_state.state.write().unwrap();
-
-    let schema = mock_state.schema.as_ref().expect("Schema not initialized");
-    let document = match ExecutableDocument::parse_and_validate(schema, query, "query.graphql") {
-        Ok(doc) => doc,
-        Err(e) => {
-            eprintln!("DEBUG: GraphQL validation errors: {:?}", e.errors);
-            return graphql_http_error("GraphQL request failed schema validation");
-        }
-    };
+    let document =
+        match ExecutableDocument::parse_and_validate(&GITHUB_SCHEMA, query, "query.graphql") {
+            Ok(doc) => doc,
+            Err(e) => {
+                eprintln!("DEBUG: GraphQL validation errors: {:?}", e.errors);
+                return graphql_http_error("GraphQL request failed schema validation");
+            }
+        };
     if let Err(message) = validate_supported_document(&document, &variables) {
         return graphql_http_error(&message);
     }
 
     let operations = graphql_operations(&document);
+    let mut mock_state = app_state.state.write().unwrap();
     mock_state.graphql_requests.push(operations.clone());
     if let Some(failure) = check_and_apply_graphql_failure(&mut mock_state, &operations) {
         return (
@@ -1189,14 +1190,9 @@ mod tests {
     use super::*;
 
     fn parse_document(query: &str) -> ExecutableDocument {
-        let state = MockState::new("owner".to_string(), "repo".to_string());
-        ExecutableDocument::parse_and_validate(
-            state.schema.as_ref().unwrap(),
-            query,
-            "test.graphql",
-        )
-        .unwrap()
-        .into_inner()
+        ExecutableDocument::parse_and_validate(&GITHUB_SCHEMA, query, "test.graphql")
+            .unwrap()
+            .into_inner()
     }
 
     fn root_field(document: &ExecutableDocument) -> &executable::Field {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Every mock context parsed and validated the 1.2 MiB GitHub schema,
making fixture creation pay a few hundred milliseconds each. The
schema also lived as an optional field under mutable mock state even
though it is immutable infrastructure.

Parse it once per test process, keep it outside MockState, and validate
requests before acquiring the state write lock. This removes impossible
uninitialized state and shortens the critical section.




---

- 　  #316
- 　  #315
- 　  #314
- 　  #313
- 　  #312
- 　  #311
- 👉 #310


**Latest Update:** v6 — [Compare vs v5](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v5..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|
|v6|[vs v5](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v5..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v6)|[vs v4](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v4..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v6)|[vs v3](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v3..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v6)|[vs v2](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v2..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v6)|[vs v1](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v1..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v6)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v6)|
|v5||[vs v4](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v4..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v5)|[vs v3](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v3..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v5)|[vs v2](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v2..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v5)|[vs v1](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v1..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v5)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v5)|
|v4|||[vs v3](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v3..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v4)|[vs v2](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v2..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v4)|[vs v1](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v1..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v4)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v4)|
|v3||||[vs v2](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v2..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v3)|[vs v1](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v1..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v3)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v3)|
|v2|||||[vs v1](/joshlf/gherrit/compare/gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v1..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v2)|[vs Base](/joshlf/gherrit/compare/main..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v2)|
|v1||||||[vs Base](/joshlf/gherrit/compare/main..gherrit/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id && git checkout -b pr-G2hpe6vpoeffnok4x4rzlrzpakiq7a5id FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G2hpe6vpoeffnok4x4rzlrzpakiq7a5id
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G2hpe6vpoeffnok4x4rzlrzpakiq7a5id", "parent": null, "child": "Gd2kgulu6v74pd6t4afjuvri7l4ckwvdk"}" -->