### PR TITLE
[pre-push] Make GraphQL batching explicit

### DIFF
--- a/src/pre_push/batching.rs
+++ b/src/pre_push/batching.rs
@@ -1,0 +1,215 @@
+use std::{num::NonZeroUsize, ops::Range};
+
+use serde_json::Value;
+
+pub(super) const INITIAL_GRAPHQL_BATCH_LEN: NonZeroUsize = NonZeroUsize::new(64).unwrap();
+pub(super) const MAX_GRAPHQL_QUERY_BYTES: usize = 256 * 1024;
+
+#[derive(Debug)]
+pub(super) struct BatchPlan {
+    item_count: usize,
+    cursor: usize,
+    batch_len: NonZeroUsize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct Backoff {
+    pub attempted: usize,
+    pub retry: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ItemTooLarge {
+    pub index: usize,
+}
+
+impl BatchPlan {
+    pub fn new(item_count: usize, max_batch_len: NonZeroUsize) -> Self {
+        Self { item_count, cursor: 0, batch_len: max_batch_len }
+    }
+
+    pub fn current(&self) -> Option<Range<usize>> {
+        (self.cursor < self.item_count)
+            .then(|| self.cursor..self.item_count.min(self.cursor + self.batch_len.get()))
+    }
+
+    pub fn accept(&mut self) {
+        self.cursor = self.current().expect("cannot accept a completed batch plan").end;
+    }
+
+    pub fn reject(&mut self) -> Result<Backoff, ItemTooLarge> {
+        let range = self.current().expect("cannot reject a completed batch plan");
+        let attempted = range.len();
+        if attempted == 1 {
+            return Err(ItemTooLarge { index: range.start });
+        }
+
+        let retry = NonZeroUsize::new(attempted / 2).expect("rejected batch has multiple items");
+        self.batch_len = retry;
+        Ok(Backoff { attempted, retry: retry.get() })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ResponseDisposition {
+    Success,
+    RetryLimit,
+    Fatal,
+}
+
+pub(super) fn query_exceeds_limit(query: &str) -> bool {
+    query.len() > MAX_GRAPHQL_QUERY_BYTES
+}
+
+pub(super) fn classify_response(response: &Value) -> ResponseDisposition {
+    let Some(errors) = response.get("errors") else {
+        return ResponseDisposition::Success;
+    };
+    let has_no_data = response.get("data").is_none_or(Value::is_null);
+    let has_only_resource_errors = errors
+        .as_array()
+        .is_some_and(|errors| !errors.is_empty() && errors.iter().all(is_resource_limit_error));
+
+    if has_no_data && has_only_resource_errors {
+        ResponseDisposition::RetryLimit
+    } else {
+        ResponseDisposition::Fatal
+    }
+}
+
+fn is_resource_limit_error(error: &Value) -> bool {
+    let is_typed_resource_error = matches!(
+        error.get("type").and_then(Value::as_str),
+        Some("RESOURCE_LIMITS_EXCEEDED" | "MAX_NODE_LIMIT_EXCEEDED")
+    );
+    // HEURISTIC: GitHub middleware has also returned this parse error after
+    // silently dropping or truncating an oversized request.
+    let is_oversized_request_error = matches!(
+        error.get("message").and_then(Value::as_str),
+        Some("A query attribute must be specified and must be a string.")
+    );
+
+    is_typed_resource_error || is_oversized_request_error
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn ranges(item_count: usize) -> Vec<Range<usize>> {
+        let mut plan = BatchPlan::new(item_count, INITIAL_GRAPHQL_BATCH_LEN);
+        let mut ranges = Vec::new();
+        while let Some(range) = plan.current() {
+            ranges.push(range);
+            plan.accept();
+        }
+        ranges
+    }
+
+    #[test]
+    fn plans_success_boundaries() {
+        assert_eq!(ranges(0), Vec::<Range<usize>>::new());
+        for (item_count, expected) in [(1, 0..1), (63, 0..63), (64, 0..64)] {
+            assert_eq!(ranges(item_count), std::iter::once(expected).collect::<Vec<_>>());
+        }
+        assert_eq!(ranges(65), [0..64, 64..65]);
+        assert_eq!(ranges(128), [0..64, 64..128]);
+    }
+
+    #[test]
+    fn backs_off_without_advancing() {
+        let mut plan = BatchPlan::new(64, INITIAL_GRAPHQL_BATCH_LEN);
+
+        for (attempted, retry) in [(64, 32), (32, 16), (16, 8), (8, 4), (4, 2), (2, 1)] {
+            assert_eq!(plan.current(), Some(0..attempted));
+            assert_eq!(plan.reject(), Ok(Backoff { attempted, retry }));
+            assert_eq!(plan.current(), Some(0..retry));
+        }
+        assert_eq!(plan.reject(), Err(ItemTooLarge { index: 0 }));
+    }
+
+    #[test]
+    fn halves_the_actual_tail_attempt() {
+        let mut plan = BatchPlan::new(100, INITIAL_GRAPHQL_BATCH_LEN);
+        assert_eq!(plan.current(), Some(0..64));
+        plan.accept();
+
+        assert_eq!(plan.current(), Some(64..100));
+        assert_eq!(plan.reject(), Ok(Backoff { attempted: 36, retry: 18 }));
+        assert_eq!(plan.current(), Some(64..82));
+    }
+
+    #[test]
+    fn rejects_a_single_tail_item_immediately() {
+        let mut plan = BatchPlan::new(65, INITIAL_GRAPHQL_BATCH_LEN);
+        plan.accept();
+
+        assert_eq!(plan.current(), Some(64..65));
+        assert_eq!(plan.reject(), Err(ItemTooLarge { index: 64 }));
+    }
+
+    #[test]
+    fn preserves_a_reduced_batch_length_after_success() {
+        let mut plan = BatchPlan::new(100, INITIAL_GRAPHQL_BATCH_LEN);
+        plan.reject().unwrap();
+        assert_eq!(plan.current(), Some(0..32));
+        plan.accept();
+        assert_eq!(plan.current(), Some(32..64));
+    }
+
+    #[test]
+    fn floors_odd_backoff_lengths() {
+        let mut plan = BatchPlan::new(3, NonZeroUsize::new(3).unwrap());
+        assert_eq!(plan.reject(), Ok(Backoff { attempted: 3, retry: 1 }));
+        assert_eq!(plan.current(), Some(0..1));
+    }
+
+    #[test]
+    fn query_limit_is_inclusive() {
+        assert!(!query_exceeds_limit(&"x".repeat(MAX_GRAPHQL_QUERY_BYTES)));
+        assert!(query_exceeds_limit(&"x".repeat(MAX_GRAPHQL_QUERY_BYTES + 1)));
+    }
+
+    #[test]
+    fn classifies_resource_limit_responses() {
+        for error in [
+            json!({ "type": "RESOURCE_LIMITS_EXCEEDED" }),
+            json!({ "type": "MAX_NODE_LIMIT_EXCEEDED" }),
+            json!({
+                "message": "A query attribute must be specified and must be a string."
+            }),
+        ] {
+            assert_eq!(
+                classify_response(&json!({ "errors": [error] })),
+                ResponseDisposition::RetryLimit
+            );
+            assert_eq!(
+                classify_response(&json!({ "data": null, "errors": [error] })),
+                ResponseDisposition::RetryLimit
+            );
+        }
+    }
+
+    #[test]
+    fn treats_partial_or_mixed_errors_as_fatal() {
+        let resource_error = json!({ "type": "RESOURCE_LIMITS_EXCEEDED" });
+        let fatal_error = json!({ "type": "FORBIDDEN" });
+
+        for response in [
+            json!({ "errors": [fatal_error.clone()] }),
+            json!({ "errors": [resource_error.clone(), fatal_error] }),
+            json!({ "errors": [] }),
+            json!({ "errors": "not an array" }),
+            json!({ "data": {}, "errors": [resource_error] }),
+        ] {
+            assert_eq!(classify_response(&response), ResponseDisposition::Fatal);
+        }
+    }
+
+    #[test]
+    fn accepts_responses_without_errors() {
+        assert_eq!(classify_response(&json!({ "data": {} })), ResponseDisposition::Success);
+    }
+}

--- a/src/pre_push/mod.rs
+++ b/src/pre_push/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    cmp,
     collections::HashMap,
     fmt::{self, Write},
     process::Stdio,
@@ -17,8 +16,13 @@ use crate::{
     util::{self, CommandExt as _, HeadState, Remote},
 };
 
+mod batching;
 mod reconcile;
 
+use batching::{
+    BatchPlan, INITIAL_GRAPHQL_BATCH_LEN, MAX_GRAPHQL_QUERY_BYTES, ResponseDisposition,
+    classify_response, query_exceeds_limit,
+};
 use reconcile::{CurrentPr, DesiredPr, PrUpdate, link_stack, plan_update};
 
 pub async fn run(repo: &util::Repo) -> Result<()> {
@@ -841,8 +845,8 @@ async fn fetch_repo_id(octocrab: &Octocrab, remote: &Remote) -> Result<String> {
 
 /// Performs batched updates of PRs using GitHub's GraphQL API.
 ///
-/// This avoids rate limits and network latency by grouping updates into chunks
-/// (default 50) and sending them as a single GraphQL operation.
+/// This avoids rate limits and network latency by grouping updates into
+/// adaptive batches and sending each batch as one GraphQL operation.
 async fn batch_update_prs(octocrab: &Octocrab, updates: Vec<PrUpdate>) -> Result<()> {
     run_batched_graphql(
         octocrab,
@@ -874,8 +878,8 @@ async fn batch_update_prs(octocrab: &Octocrab, updates: Vec<PrUpdate>) -> Result
 
 /// Performs batched creation of PRs using GitHub's GraphQL API.
 ///
-/// This avoids rate limits and network latency by grouping creations into chunks
-/// (default 50) and sending them as a single GraphQL operation.
+/// This avoids rate limits and network latency by grouping creations into
+/// adaptive batches and sending each batch as one GraphQL operation.
 ///
 /// Returns a map of head branch name -> (number, url, node_id) for the newly
 /// created PRs.
@@ -986,8 +990,8 @@ enum GraphQlOp {
 
 /// Executes batched GraphQL operations (queries or mutations).
 ///
-/// Iterates over items in chunks of 50, builds a combined query string using
-/// `query_builder`, and processes the response using `response_handler`.
+/// Builds a combined query for each adaptive batch and processes each
+/// operation in a successful response with `response_handler`.
 async fn run_batched_graphql<T, M, H>(
     octocrab: &Octocrab,
     operation_type: GraphQlOp,
@@ -1004,24 +1008,22 @@ where
         return Ok(());
     }
 
-    let alias = |i| format!("op{i}");
+    let alias = |index| format!("op{index}");
 
     // GitHub imposes a limit on the number of nodes that can be processed in a
     // single GraphQL query (500,000 as of this writing [1]), and also imposes
     // limits on the amount of computation resources required to process the
     // query [2]. In order to avoid hitting these limits while still processing
-    // large batches in the optimistic case, we start with a large match size
+    // large batches in the optimistic case, we start with a large batch size
     // and perform exponential backoff if we hit the limits. This also ensures
     // that we are resilient in the face of GitHub changing these limits in the
     // future.
     //
     // [1] https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#node-limit
     // [2] https://github.blog/changelog/2025-09-01-graphql-api-resource-limits/
-    let mut batch_size = cmp::min(64, items.len());
-    let mut cursor = 0;
-    while cursor < items.len() {
-        let end = cmp::min(cursor + batch_size, items.len());
-        let chunk = &items[cursor..end];
+    let mut batches = BatchPlan::new(items.len(), INITIAL_GRAPHQL_BATCH_LEN);
+    while let Some(range) = batches.current() {
+        let chunk = &items[range];
 
         let query_body: String = chunk
             .iter()
@@ -1047,12 +1049,11 @@ where
             // requests larger than ~600KB, leading to confusing "missing query
             // attribute" errors. We preemptively backoff if we exceed a
             // conservative limit (256KB).
-            const MAX_QUERY_SIZE: usize = 256 * 1024; // 256 KB
-            if query.len() > MAX_QUERY_SIZE {
+            if query_exceeds_limit(&query) {
                 log::warn!(
                     "GraphQL query size ({} bytes) exceeds heuristic limit ({} bytes).",
                     query.len(),
-                    MAX_QUERY_SIZE
+                    MAX_GRAPHQL_QUERY_BYTES
                 );
                 return Ok(None);
             }
@@ -1064,46 +1065,38 @@ where
                 .await
                 .wrap_err("GraphQL batched operation failed")?;
 
-            if let Some(errors) = response.get("errors") {
-                let is_resource_limit = errors.as_array().is_some_and(|errs| {
-                    errs.iter().any(|e| {
-                        let type_str = e.get("type").and_then(|t| t.as_str());
-                        let msg_str = e.get("message").and_then(|m| m.as_str());
-
-                        matches!(type_str, Some("RESOURCE_LIMITS_EXCEEDED" | "MAX_NODE_LIMIT_EXCEEDED"))
-                        // HEURISTIC: We've seen this specific error message in
-                        // practice, likely due to the middleware issue
-                        // described above. We assume it's as a result of an
-                        // overly-large query.
-                        || matches!(msg_str, Some("A query attribute must be specified and must be a string."))
-                    })
-                });
-
-                if is_resource_limit {
-                    log::warn!("Hit GitHub resource limit with GraphQL batch update of size {batch_size}");
+            match classify_response(&response) {
+                ResponseDisposition::Success => {}
+                ResponseDisposition::RetryLimit => {
+                    log::warn!(
+                        "Hit GitHub resource limit with GraphQL batch of size {}",
+                        chunk.len()
+                    );
                     return Ok(None);
                 }
-
-                log::error!("GraphQL errors: {}", errors);
-                bail!("GraphQL errors: {:?}", errors);
+                ResponseDisposition::Fatal => {
+                    let errors = response.get("errors").expect("fatal response has errors");
+                    log::error!("GraphQL errors: {errors}");
+                    bail!("GraphQL errors: {errors:?}");
+                }
             }
 
             Ok(Some(response))
-        }.await?;
+        }
+        .await?;
 
         let Some(response) = response else {
-            let new_batch_size = batch_size / 2;
-            log::warn!("Backing off batch size from {batch_size} to {new_batch_size}.");
-
-            if new_batch_size == 0 {
-                // NOTE: Since we always divide by 2, we're guaranteed to never
-                // skip 1 (4 -> 2 -> 1 and 3 -> 1), so we know that if we reach
-                // this point, a single PR update exceeds GitHub's limits.
-                //
-                // FIXME: In this case, fall back to the REST API.
-                bail!("Single PR update exceeds GitHub resource limits. Cannot sync.");
+            match batches.reject() {
+                Ok(backoff) => log::warn!(
+                    "Backing off GraphQL batch size from {} to {}.",
+                    backoff.attempted,
+                    backoff.retry
+                ),
+                Err(item) => bail!(
+                    "GraphQL operation at item {} exceeds GitHub resource limits. Cannot sync.",
+                    item.index
+                ),
             }
-            batch_size = new_batch_size;
             continue;
         };
 
@@ -1115,7 +1108,7 @@ where
             response_handler(item, op_data)?;
         }
 
-        cursor = end;
+        batches.accept();
     }
     Ok(())
 }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

GraphQL batching mixed cursor advancement, exponential backoff, query
limits, transport, and error classification in one async loop. Its
tail batches could retry the same request repeatedly, and a response
containing both resource and fatal errors was treated as retryable.

Move batch transitions and response classification into a pure model
whose maximum and current batch sizes are statically nonzero. Back off
from the size actually attempted, fail immediately for a single
rejected operation, and retry only recognized limit failures without
partial data. Cover empty and exact boundaries, tails, odd and
persistent backoff, query size, and mixed response errors.




---

- 　  #317
- 　  #316
- 　  #315
- 　  #314
- 　  #313
- 👉 #312


**Latest Update:** v13 — [Compare vs v12](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v12 | v11 | v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v13|[v12](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v11](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v10](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v9](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v8](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v7](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v6](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v5](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v13)|
|v12||[v11](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v10](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v9](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v8](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v7](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v6](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v5](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v12)|
|v11|||[v10](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v9](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v8](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v7](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v6](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v5](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v11)|
|v10||||[v9](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[v8](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[v7](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[v6](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[v5](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v10)|
|v9|||||[v8](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|[v7](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|[v6](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|[v5](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v9)|
|v8||||||[v7](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8)|[v6](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8)|[v5](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8)|[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v8)|
|v7|||||||[v6](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7)|[v5](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7)|[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v7)|
|v6||||||||[v5](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6)|[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v6)|
|v5|||||||||[v4](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5)|[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v5)|
|v4||||||||||[v3](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4)|[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v4)|
|v3|||||||||||[v2](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3)|[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v3)|
|v2||||||||||||[v1](/joshlf/gherrit/compare/gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2)|[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v2)|
|v1|||||||||||||[Base](/joshlf/gherrit/compare/main..gherrit/G4ibghckltemi4ywq7kxzi6kkm5vt37tb/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G4ibghckltemi4ywq7kxzi6kkm5vt37tb && git checkout -b pr-G4ibghckltemi4ywq7kxzi6kkm5vt37tb FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G4ibghckltemi4ywq7kxzi6kkm5vt37tb && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G4ibghckltemi4ywq7kxzi6kkm5vt37tb && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G4ibghckltemi4ywq7kxzi6kkm5vt37tb
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"G4ibghckltemi4ywq7kxzi6kkm5vt37tb","parent":null,"child":"Go24aevpunzxf3vzhyw3w4jirdqzi7vj4"} -->