### PR TITLE
[pre-push] Make Git publication batches explicit

### DIFF
--- a/src/pre_push/mod.rs
+++ b/src/pre_push/mod.rs
@@ -17,12 +17,14 @@ use crate::{
 };
 
 mod batching;
+mod publication;
 mod reconcile;
 
 use batching::{
     BatchPlan, INITIAL_GRAPHQL_BATCH_LEN, MAX_GRAPHQL_QUERY_BYTES, ResponseDisposition,
     classify_response, query_exceeds_limit,
 };
+use publication::{PushTarget, plan_push, push_batches, remote_query_batches};
 use reconcile::{CurrentPr, DesiredPr, PrUpdate, link_stack, plan_update};
 
 pub async fn run(repo: &util::Repo) -> Result<()> {
@@ -164,14 +166,8 @@ fn push_to_origin(repo: &util::Repo, commits: &[Commit]) -> Result<HashMap<Strin
 
     let mut next_versions = HashMap::new();
 
-    // Windows command line limit is ~32k chars. Each commit generates ~200
-    // chars of refspecs (1 branch ref + 1 tag ref).
-    // 80 * 200 = 16,000 chars, leaving plenty of headroom.
-    const BATCH_SIZE: usize = 80;
-
-    for chunk in commits.chunks(BATCH_SIZE) {
-        let mut refspecs = Vec::new();
-        let mut refs_to_persist = Vec::new();
+    for chunk in push_batches(commits) {
+        let mut targets = Vec::with_capacity(chunk.len());
 
         for c in chunk {
             // Determine the next version based on local tags (Optimistic
@@ -188,38 +184,18 @@ fn push_to_origin(repo: &util::Repo, commits: &[Commit]) -> Result<HashMap<Strin
                 .map(|s| s.as_deref().unwrap_or(""))
                 .unwrap_or("");
 
-            refspecs.push(format!("{}:refs/heads/{}", c.id, c.gherrit_id));
-            refspecs.push(format!("--force-with-lease=refs/heads/{}:{expected_sha}", c.gherrit_id));
-
-            // Lock the next version tag to prevent concurrent pushes of the
-            // same version. `--force-with-lease=<ref>:` means "expect the ref
-            // to NOT exist", and causes the server to fail the operation if it
-            // does exist. This prevents overwriting if someone else pushed
-            // next_ver already.
-            refspecs.push(format!("{}:refs/tags/gherrit/{}/v{}", c.id, c.gherrit_id, next_ver));
-            refspecs.push(format!(
-                "--force-with-lease=refs/tags/gherrit/{}/v{next_ver}:",
-                c.gherrit_id
-            ));
-
-            refs_to_persist.push((c.id, c.gherrit_id.clone(), next_ver));
+            targets.push(PushTarget {
+                object_id: c.id,
+                gherrit_id: &c.gherrit_id,
+                version: next_ver,
+                expected_remote_sha: expected_sha,
+            });
         }
 
-        if refspecs.is_empty() {
-            continue;
-        }
-
-        let mut args = vec![
-            "push".to_string(),
-            "--quiet".to_string(),
-            "--no-verify".to_string(),
-            "--atomic".to_string(), // Critical for the lock to work
-            repo.default_remote_name(),
-        ];
-        args.extend(refspecs);
+        let plan = plan_push(&repo.default_remote_name(), &targets);
 
         log::info!("Pushing chunk to remote...");
-        let mut child = util::cmd("git", args)
+        let mut child = util::cmd("git", plan.arguments)
             .stdout(Stdio::inherit())
             .stderr(Stdio::piped())
             .spawn()
@@ -269,10 +245,10 @@ fn push_to_origin(repo: &util::Repo, commits: &[Commit]) -> Result<HashMap<Strin
         }
 
         // Persist the local tags now that the push succeeded.
-        for (id, gherrit_id, ver) in refs_to_persist {
+        for tag in plan.persisted_tags {
             let _ = repo.reference(
-                format!("refs/tags/gherrit/{gherrit_id}/v{ver}"),
-                id,
+                format!("refs/tags/gherrit/{}/v{}", tag.gherrit_id, tag.version),
+                tag.object_id,
                 PreviousValue::Any,
                 "gherrit: persist local version state",
             );
@@ -287,13 +263,8 @@ fn get_remote_branch_states(
     repo: &util::Repo,
     gherrit_ids: &[String],
 ) -> Result<HashMap<String, Option<String>>> {
-    // Batch size is limited to avoid exceeding command line limits (e.g.,
-    // Windows 32k chars). Each refspec is ~62 chars. 250 * 62 = 15,500
-    // chars (safe).
-    const BATCH_SIZE: usize = 250;
-
     let mut states: HashMap<String, Option<String>> = HashMap::new();
-    for chunk in gherrit_ids.chunks(BATCH_SIZE) {
+    for chunk in remote_query_batches(gherrit_ids) {
         let mut args = vec!["ls-remote".to_string(), repo.default_remote_name()];
         args.extend(chunk.iter().map(|id| format!("refs/heads/{id}")));
 

--- a/src/pre_push/publication.rs
+++ b/src/pre_push/publication.rs
@@ -1,0 +1,154 @@
+use std::slice;
+
+use gix::ObjectId;
+
+// Windows command lines are limited to roughly 32 KiB. Each target contributes
+// about 200 characters of branch and tag refspecs, so 80 targets leave ample
+// headroom.
+const PUSH_BATCH_LEN: usize = 80;
+// Each queried branch is about 62 characters, making 250 branches roughly
+// 15.5 KiB.
+const REMOTE_QUERY_BATCH_LEN: usize = 250;
+
+pub(super) struct PushTarget<'a> {
+    pub object_id: ObjectId,
+    pub gherrit_id: &'a str,
+    pub version: usize,
+    pub expected_remote_sha: &'a str,
+}
+
+pub(super) struct PersistedTag {
+    pub object_id: ObjectId,
+    pub gherrit_id: String,
+    pub version: usize,
+}
+
+pub(super) struct PushPlan {
+    pub arguments: Vec<String>,
+    pub persisted_tags: Vec<PersistedTag>,
+}
+
+pub(super) fn push_batches<T>(items: &[T]) -> slice::Chunks<'_, T> {
+    items.chunks(PUSH_BATCH_LEN)
+}
+
+pub(super) fn remote_query_batches<T>(items: &[T]) -> slice::Chunks<'_, T> {
+    items.chunks(REMOTE_QUERY_BATCH_LEN)
+}
+
+pub(super) fn plan_push(remote: &str, targets: &[PushTarget<'_>]) -> PushPlan {
+    assert!(!targets.is_empty(), "cannot plan an empty push");
+    let refspecs = targets.iter().flat_map(|target| {
+        let branch = format!("refs/heads/{}", target.gherrit_id);
+        let tag = format!("refs/tags/gherrit/{}/v{}", target.gherrit_id, target.version);
+        // Branch updates are leased against the observed remote value. A tag
+        // lease with an empty expected value requires that the version tag not
+        // exist, making it a lock rather than an overwrite.
+        [
+            format!("{}:{branch}", target.object_id),
+            format!("--force-with-lease={branch}:{}", target.expected_remote_sha),
+            format!("{}:{tag}", target.object_id),
+            format!("--force-with-lease={tag}:"),
+        ]
+    });
+    let arguments = ["push", "--quiet", "--no-verify", "--atomic", remote]
+        .into_iter()
+        .map(ToString::to_string)
+        .chain(refspecs)
+        .collect();
+    let persisted_tags = targets
+        .iter()
+        .map(|target| PersistedTag {
+            object_id: target.object_id,
+            gherrit_id: target.gherrit_id.to_string(),
+            version: target.version,
+        })
+        .collect();
+
+    PushPlan { arguments, persisted_tags }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn batch_lengths(batches: slice::Chunks<'_, usize>) -> Vec<usize> {
+        batches.map(<[usize]>::len).collect()
+    }
+
+    fn object_id(byte: u8) -> ObjectId {
+        ObjectId::from_bytes_or_panic(&[byte; 20])
+    }
+
+    #[test]
+    fn plans_push_batch_boundaries() {
+        for (item_count, expected) in [
+            (0, vec![]),
+            (1, vec![1]),
+            (79, vec![79]),
+            (80, vec![80]),
+            (81, vec![80, 1]),
+            (160, vec![80, 80]),
+            (161, vec![80, 80, 1]),
+        ] {
+            let items = (0..item_count).collect::<Vec<_>>();
+            assert_eq!(batch_lengths(push_batches(&items)), expected);
+        }
+    }
+
+    #[test]
+    fn plans_remote_query_batch_boundaries() {
+        for (item_count, expected) in
+            [(0, vec![]), (1, vec![1]), (250, vec![250]), (251, vec![250, 1])]
+        {
+            let items = (0..item_count).collect::<Vec<_>>();
+            assert_eq!(batch_lengths(remote_query_batches(&items)), expected);
+        }
+    }
+
+    #[test]
+    fn plans_atomic_branch_and_tag_leases() {
+        let targets = [
+            PushTarget {
+                object_id: object_id(0x11),
+                gherrit_id: "Gone",
+                version: 2,
+                expected_remote_sha: "abc123",
+            },
+            PushTarget {
+                object_id: object_id(0x22),
+                gherrit_id: "Gtwo",
+                version: 1,
+                expected_remote_sha: "",
+            },
+        ];
+
+        let plan = plan_push("origin", &targets);
+
+        assert_eq!(
+            plan.arguments,
+            [
+                "push".to_string(),
+                "--quiet".to_string(),
+                "--no-verify".to_string(),
+                "--atomic".to_string(),
+                "origin".to_string(),
+                format!("{}:refs/heads/Gone", object_id(0x11)),
+                "--force-with-lease=refs/heads/Gone:abc123".to_string(),
+                format!("{}:refs/tags/gherrit/Gone/v2", object_id(0x11)),
+                "--force-with-lease=refs/tags/gherrit/Gone/v2:".to_string(),
+                format!("{}:refs/heads/Gtwo", object_id(0x22)),
+                "--force-with-lease=refs/heads/Gtwo:".to_string(),
+                format!("{}:refs/tags/gherrit/Gtwo/v1", object_id(0x22)),
+                "--force-with-lease=refs/tags/gherrit/Gtwo/v1:".to_string(),
+            ]
+        );
+        assert_eq!(plan.persisted_tags.len(), 2);
+        assert_eq!(plan.persisted_tags[0].object_id, object_id(0x11));
+        assert_eq!(plan.persisted_tags[0].gherrit_id, "Gone");
+        assert_eq!(plan.persisted_tags[0].version, 2);
+        assert_eq!(plan.persisted_tags[1].object_id, object_id(0x22));
+        assert_eq!(plan.persisted_tags[1].gherrit_id, "Gtwo");
+        assert_eq!(plan.persisted_tags[1].version, 1);
+    }
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Git publication assembled branch and version-tag refspecs inside the
loop that executes each push. Its 80-commit and 250-query boundaries,
lease construction, and tag persistence inputs were covered only by
an 85-commit end-to-end test.

Move fixed-size partitioning and atomic push construction into a pure
publication model. Preserve per-batch version lookup and execution,
and cover exact boundaries plus branch leases, create-only tag leases,
argument order, and persisted tag identity.




---

- 　  #317
- 　  #316
- 　  #315
- 　  #314
- 👉 #313


**Latest Update:** v13 — [Compare vs v12](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v12 | v11 | v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v13|[v12](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v11](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v10](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v9](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v8](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v7](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v6](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v5](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v13)|
|v12||[v11](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v10](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v9](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v8](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v7](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v6](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v5](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v12)|
|v11|||[v10](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v9](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v8](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v7](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v6](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v5](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v11)|
|v10||||[v9](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[v8](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[v7](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[v6](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[v5](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v10)|
|v9|||||[v8](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|[v7](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|[v6](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|[v5](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v9)|
|v8||||||[v7](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8)|[v6](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8)|[v5](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8)|[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v8)|
|v7|||||||[v6](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7)|[v5](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7)|[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v7)|
|v6||||||||[v5](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6)|[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v6)|
|v5|||||||||[v4](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5)|[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v5)|
|v4||||||||||[v3](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4)|[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v4)|
|v3|||||||||||[v2](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3)|[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v3)|
|v2||||||||||||[v1](/joshlf/gherrit/compare/gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2)|[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v2)|
|v1|||||||||||||[Base](/joshlf/gherrit/compare/main..gherrit/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4 && git checkout -b pr-Go24aevpunzxf3vzhyw3w4jirdqzi7vj4 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Go24aevpunzxf3vzhyw3w4jirdqzi7vj4
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Go24aevpunzxf3vzhyw3w4jirdqzi7vj4","parent":null,"child":"G4vbmfh3wcpqpzosunasgtvklkcqv3j3j"} -->