### PR TITLE
Temporary CI bootstrap artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
 
       - name: Archive bootstrap workspace
         run: |
+          cargo build --locked
           rm -rf /tmp/gherrit-bootstrap
           mkdir -p /tmp/gherrit-bootstrap bootstrap
           cp target/debug/gherrit /tmp/gherrit-bootstrap/gherrit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Get Rust Version
         id: rust-version
@@ -53,6 +55,19 @@ jobs:
 
       - name: Test stack metadata parser
         run: bash ci/test_extract_stack_child.sh
+
+      - name: Build bootstrap binary and archive checkout
+        run: |
+          cargo build --release --locked
+          mkdir -p bootstrap
+          cp target/release/gherrit bootstrap/gherrit
+          tar --exclude='./target' --exclude='./bootstrap' -czf bootstrap/workspace.tar.gz .
+
+      - name: Upload bootstrap workspace
+        uses: actions/upload-artifact@v4
+        with:
+          name: gherrit-bootstrap
+          path: bootstrap/
 
   windows-tests:
     name: Windows Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   validate:
     name: Validate and Test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -65,11 +65,32 @@ jobs:
           tar --exclude='./target' -czf /tmp/gherrit-bootstrap/workspace.tar.gz .
           cp /tmp/gherrit-bootstrap/* bootstrap/
 
+      - name: Archive Rust toolchain and dependency cache
+        run: |
+          toolchain=$(rustup which --toolchain "${{ steps.rust-version.outputs.version }}" rustc)
+          toolchain=$(dirname "$(dirname "$toolchain")")
+          rm -rf /tmp/rust-bootstrap bootstrap-rust
+          mkdir -p /tmp/rust-bootstrap/toolchain /tmp/rust-bootstrap/cargo-home bootstrap-rust
+          cp -a "$toolchain"/. /tmp/rust-bootstrap/toolchain/
+          if [ -d "$HOME/.cargo/registry" ]; then
+            cp -a "$HOME/.cargo/registry" /tmp/rust-bootstrap/cargo-home/
+          fi
+          if [ -d "$HOME/.cargo/git" ]; then
+            cp -a "$HOME/.cargo/git" /tmp/rust-bootstrap/cargo-home/
+          fi
+          tar -czf bootstrap-rust/rust-bootstrap.tar.gz -C /tmp/rust-bootstrap .
+
       - name: Upload bootstrap workspace
         uses: actions/upload-artifact@v4
         with:
           name: gherrit-bootstrap
           path: bootstrap/
+
+      - name: Upload Rust bootstrap
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-bootstrap
+          path: bootstrap-rust/
 
   windows-tests:
     name: Windows Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,13 @@ jobs:
       - name: Test stack metadata parser
         run: bash ci/test_extract_stack_child.sh
 
-      - name: Build bootstrap binary and archive checkout
+      - name: Archive bootstrap workspace
         run: |
-          cargo build --release --locked
-          mkdir -p bootstrap
-          cp target/release/gherrit bootstrap/gherrit
-          tar --exclude='./target' --exclude='./bootstrap' -czf bootstrap/workspace.tar.gz .
+          rm -rf /tmp/gherrit-bootstrap
+          mkdir -p /tmp/gherrit-bootstrap bootstrap
+          cp target/debug/gherrit /tmp/gherrit-bootstrap/gherrit
+          tar --exclude='./target' -czf /tmp/gherrit-bootstrap/workspace.tar.gz .
+          cp /tmp/gherrit-bootstrap/* bootstrap/
 
       - name: Upload bootstrap workspace
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Temporary draft PR used only to build a GHerrit binary and archive a full checkout for the implementation environment. It will be closed and its branch deleted after the artifact is retrieved.